### PR TITLE
Estilizando a home de usuário

### DIFF
--- a/developer-env/templates/configmaps/user-apps-html.yaml
+++ b/developer-env/templates/configmaps/user-apps-html.yaml
@@ -86,9 +86,7 @@ data:
     		}
     	</style>
     </head>
-    
     <body class="container">
-    
     	<header>
     		<nav>
     			<ul>
@@ -163,7 +161,6 @@ data:
     			<kbd>ssh {{lower .username}}@localhost -p EXPOSED_PORT</kbd>
     		</p>
     	</main>
-    
     	<script>
         function setTheme(theme) {
           if (!theme) return;
@@ -190,5 +187,4 @@ data:
         onLoad();
     	</script>
     </body>
-
 {{- end }}

--- a/developer-env/templates/configmaps/user-apps-html.yaml
+++ b/developer-env/templates/configmaps/user-apps-html.yaml
@@ -11,455 +11,177 @@ data:
   index.html: |
     <!DOCTYPE html>
     <head>
-      <title>DEV</title>
-      <meta charset="UTF-8">
-      <link rel="icon"
-        href="data:image/svg+xml,%3Csvg width='800px' height='800px' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3E%0Apath %7B fill: %2360903e; %7D%0A@media (prefers-color-scheme: dark) %7B%0Apath %7B fill: %23acd36c; %7D%0A%7D%0A.booster %7B stroke: %23f57c00; %7D%0A%3C/style%3E%3Cpath d='M0.792725 12.2929L5.08562 8.00002L0.792725 3.70712L2.20694 2.29291L7.91405 8.00002L2.20694 13.7071L0.792725 12.2929Z'/%3E%3Cpath d='M7.00006 15H15.0001V13H7.00006V15Z'/%3E%3C/svg%3E"
-        sizes="any" type="image/svg+xml" />
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.cyan.min.css">
-      <style>
-        svg:not(:host),
-        svg:not(:root) {
-          overflow: hidden;
-          vertical-align: text-bottom;
-        }
-
-        svg.theme-toggle {
-          display: inline-block;
-          width: auto;
-        }
-
-        svg.icon-theme-toggle {
-          --theme-toggle-duration: .4s;
-        }
-
-        svg.icon-theme-toggle.moon :first-child path {
-          d: path("M-9 3h25a1 1 0 0017 13v30H0Z");
-          transition-delay: calc(var(--theme-toggle-duration) * .4);
-          transition-timing-function:
-            cubic-bezier(0, 0, 0, 1.25);
-        }
-
-        svg.icon-theme-toggle g circle,
-        svg.icon-theme-toggle g path {
-          transform-origin: center;
-          transition: transform calc(var(--theme-toggle-duration) * .65) cubic-bezier(0, 0, 0, 1.25) calc(var(--theme-toggle-duration) * .35);
-        }
-
-        svg.icon-theme-toggle :first-child path {
-          transition-duration: calc(var(--theme-toggle-duration) * .6);
-          transition-property: transform, d;
-          transition-timing-function:
-            cubic-bezier(0, 0, .5, 1);
-        }
-
-        svg.icon-theme-toggle :first-child path {
-          transition-duration: calc(var(--theme-toggle-duration) * .6);
-          transition-property: transform, d;
-          transition-timing-function:
-            cubic-bezier(0, 0, .5, 1);
-        }
-
-        svg.icon-theme-toggle.moon g path {
-          transform: scale(.75);
-          transition-delay: 0s;
-        }
-
-        svg.icon-theme-toggle.moon g circle {
-          transform: scale(1.4);
-          transition-delay: 0s;
-        }
-
-        svg.icon-theme-toggle g circle,
-        svg.icon-theme-toggle g path {
-          transform-origin: center;
-          transition: transform calc(var(--theme-toggle-duration) * .65) cubic-bezier(0, 0, 0, 1.25) calc(var(--theme-toggle-duration) * .35);
-        }
-
-        svg.icon-theme-toggle.moon g path {
-          transform: scale(.75);
-          transition-delay: 0s;
-        }
-
-        a {
-          text-decoration-style: wavy;
-        }
-
-        main ul li a svg {
-          margin-right: 0.5rem;
-        }
-      </style>
+    	<title>DEV</title>
+    	<meta charset="UTF-8">
+    	<link rel="icon"
+    		href="data:image/svg+xml,%3Csvg width='800px' height='800px' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3E%0Apath %7B fill: %2360903e; %7D%0A@media (prefers-color-scheme: dark) %7B%0Apath %7B fill: %23acd36c; %7D%0A%7D%0A.booster %7B stroke: %23f57c00; %7D%0A%3C/style%3E%3Cpath d='M0.792725 12.2929L5.08562 8.00002L0.792725 3.70712L2.20694 2.29291L7.91405 8.00002L2.20694 13.7071L0.792725 12.2929Z'/%3E%3Cpath d='M7.00006 15H15.0001V13H7.00006V15Z'/%3E%3C/svg%3E"
+    		sizes="any" type="image/svg+xml" />
+    	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.cyan.min.css">
+    	<style>
+    		svg:not(:host),
+    		svg:not(:root) {
+    			overflow: hidden;
+    			vertical-align: text-bottom;
+    		}
+    
+    		svg.theme-toggle {
+    			display: inline-block;
+    			width: auto;
+    		}
+    
+    		svg.icon-theme-toggle {
+    			--theme-toggle-duration: .4s;
+    		}
+    
+    		svg.icon-theme-toggle.moon :first-child path {
+    			d: path("M-9 3h25a1 1 0 0017 13v30H0Z");
+    			transition-delay: calc(var(--theme-toggle-duration) * .4);
+    			transition-timing-function:
+    				cubic-bezier(0, 0, 0, 1.25);
+    		}
+    
+    		svg.icon-theme-toggle g circle,
+    		svg.icon-theme-toggle g path {
+    			transform-origin: center;
+    			transition: transform calc(var(--theme-toggle-duration) * .65) cubic-bezier(0, 0, 0, 1.25) calc(var(--theme-toggle-duration) * .35);
+    		}
+    
+    		svg.icon-theme-toggle :first-child path {
+    			transition-duration: calc(var(--theme-toggle-duration) * .6);
+    			transition-property: transform, d;
+    			transition-timing-function:
+    				cubic-bezier(0, 0, .5, 1);
+    		}
+    
+    		svg.icon-theme-toggle :first-child path {
+    			transition-duration: calc(var(--theme-toggle-duration) * .6);
+    			transition-property: transform, d;
+    			transition-timing-function:
+    				cubic-bezier(0, 0, .5, 1);
+    		}
+    
+    		svg.icon-theme-toggle.moon g path {
+    			transform: scale(.75);
+    			transition-delay: 0s;
+    		}
+    
+    		svg.icon-theme-toggle.moon g circle {
+    			transform: scale(1.4);
+    			transition-delay: 0s;
+    		}
+    
+    		svg.icon-theme-toggle g circle,
+    		svg.icon-theme-toggle g path {
+    			transform-origin: center;
+    			transition: transform calc(var(--theme-toggle-duration) * .65) cubic-bezier(0, 0, 0, 1.25) calc(var(--theme-toggle-duration) * .35);
+    		}
+    
+    		svg.icon-theme-toggle.moon g path {
+    			transform: scale(.75);
+    			transition-delay: 0s;
+    		}
+    
+    		a {
+    			text-decoration-style: wavy;
+    		}
+    	</style>
     </head>
+    
     <body class="container">
-      <header>
-        <nav>
-          <ul>
-            <li>
-              <h2>Welcome, {{lower .username}}!</h2>
-            </li>
-          </ul>
-          <ul>
-            <li><a href="/" class="contrast" style="text-decoration-style: wavy;">Controller</a></li>
-            <li><a href="#" id="theme-switcher" class="contrast"><svg xmlns="http://www.w3.org/2000/svg" width="24"
-                  height="24" viewBox="0 0 32 32" fill="currentColor" class="icon-theme-toggle theme-toggle">
-                  <clipPath id="theme-toggle-cutout">
-                    <path d="M0-11h25a1 1 0 0017 13v30H0Z"></path>
-                  </clipPath>
-                  <g clip-path="url(#theme-toggle-cutout)">
-                    <circle cx="16" cy="16" r="8.4"></circle>
-                    <path
-                      d="M18.3 3.2c0 1.3-1 2.3-2.3 2.3s-2.3-1-2.3-2.3S14.7.9 16 .9s2.3 1 2.3 2.3zm-4.6 25.6c0-1.3 1-2.3 2.3-2.3s2.3 1 2.3 2.3-1 2.3-2.3 2.3-2.3-1-2.3-2.3zm15.1-10.5c-1.3 0-2.3-1-2.3-2.3s1-2.3 2.3-2.3 2.3 1 2.3 2.3-1 2.3-2.3 2.3zM3.2 13.7c1.3 0 2.3 1 2.3 2.3s-1 2.3-2.3 2.3S.9 17.3.9 16s1-2.3 2.3-2.3zm5.8-7C9 7.9 7.9 9 6.7 9S4.4 8 4.4 6.7s1-2.3 2.3-2.3S9 5.4 9 6.7zm16.3 21c-1.3 0-2.3-1-2.3-2.3s1-2.3 2.3-2.3 2.3 1 2.3 2.3-1 2.3-2.3 2.3zm2.4-21c0 1.3-1 2.3-2.3 2.3S23 7.9 23 6.7s1-2.3 2.3-2.3 2.4 1 2.4 2.3zM6.7 23C8 23 9 24 9 25.3s-1 2.3-2.3 2.3-2.3-1-2.3-2.3 1-2.3 2.3-2.3z">
-                    </path>
-                  </g>
-                </svg></a></li>
-          </ul>
-        </nav>
-      </header>
-      <main>
-        <h3>Tools</h3>
-        <div class="grid">
-          <article>
-            <h4>IDEs</h4>
-            <ul>
-              <li><a href="./code/" target="_blank"><svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve"
-                    width="24" height="24" viewBox="0 0 512 512">
-                    <linearGradient id="visual-studio-code_svg__a" x1="256.012" x2="256.012" y1="125.867"
-                      y2="512.567" gradientTransform="matrix(1 0 0 -1 0 514)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset="0" style="stop-color:#116faf" />
-                      <stop offset=".319" style="stop-color:#247bb5" />
-                      <stop offset=".708" style="stop-color:#3585bb" />
-                      <stop offset="1" style="stop-color:#3b89bd" />
-                    </linearGradient>
-                    <path
-                      d="M493.8 55.4 388.4 4.6c-12.2-5.9-26.7-3.4-36.3 6.2L7 325.5c-9.3 8.5-9.3 23.1 0 31.5l28.2 25.6c7.6 6.9 19.1 7.4 27.2 1.2L478 68.6c13.9-10.6 34-.6 34 16.9v-1.2c0-12.4-7.1-23.6-18.2-28.9"
-                      style="fill:url(#visual-studio-code_svg__a)" />
-                    <linearGradient id="visual-studio-code_svg__b" x1="256.012" x2="256.012" y1="3.433"
-                      y2="390.133" gradientTransform="matrix(1 0 0 -1 0 514)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset="0" style="stop-color:#027bcc" />
-                      <stop offset="1" style="stop-color:#3093d6" />
-                    </linearGradient>
-                    <path
-                      d="m493.8 456.6-105.4 50.8c-12.2 5.9-26.7 3.4-36.3-6.2L7 186.5c-9.3-8.5-9.3-23.1 0-31.5l28.2-25.6c7.6-6.9 19.1-7.4 27.2-1.2L478 443.4c13.9 10.6 34 .6 34-16.9v1.2c0 12.4-7.1 23.6-18.2 28.9"
-                      style="fill:url(#visual-studio-code_svg__b)" />
-                    <linearGradient id="visual-studio-code_svg__c" x1="432.1" x2="432.1" y1="3.433"
-                      y2="512.423" gradientTransform="matrix(1 0 0 -1 0 514)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset="0" style="stop-color:#229df0" />
-                      <stop offset="1" style="stop-color:#4fb1f3" />
-                    </linearGradient>
-                    <path
-                      d="M388.5 507.4c-12.2 5.9-26.7 3.4-36.3-6.2 11.8 11.8 32 3.4 32-13.2V24.1c0-16.6-20.2-25-32-13.2 9.6-9.6 24.1-12 36.3-6.2l105.3 50.7A31.98 31.98 0 0 1 512 84.3V428c0 12.3-7.1 23.5-18.2 28.9z"
-                      style="fill:url(#visual-studio-code_svg__c)" />
-                  </svg>Code</a></li>
-              <li><a href="./jupyter/"><svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="24"
-                    height="24" viewBox="0 0 512 512">
-                    <path
-                      d="M436.5 29c.4 6.1-1.1 12.2-4.2 17.5s-7.7 9.5-13.2 12.2-11.7 3.6-17.8 2.8c-6.1-.9-11.8-3.5-16.3-7.6-4.6-4.1-7.8-9.5-9.3-15.4-1.5-6-1.2-12.2.9-18S382.4 9.7 387.4 6s10.9-5.7 17-6c4-.2 8 .4 11.8 1.7s7.3 3.4 10.3 6.1 5.4 6 7.1 9.6c1.7 3.7 2.7 7.6 2.9 11.6"
-                      style="fill:#767677" />
-                    <path
-                      d="M143.3 470.7c.5 7.7-1.3 15.4-5.2 22.1s-9.7 12-16.7 15.4-14.8 4.6-22.4 3.5c-7.7-1.1-14.8-4.4-20.6-9.6-5.7-5.2-9.8-11.9-11.7-19.4s-1.5-15.4 1.1-22.7 7.3-13.6 13.5-18.2 13.7-7.2 21.4-7.6c5.1-.3 10.1.5 14.9 2.1 4.8 1.7 9.2 4.3 12.9 7.7 3.8 3.4 6.8 7.5 9 12.1 2.3 4.5 3.6 9.5 3.8 14.6"
-                      style="fill:#9e9e9e" />
-                    <path
-                      d="M74.2 93.4c-4.4.1-8.8-1.1-12.5-3.4s-6.7-5.8-8.5-9.8-2.4-8.5-1.7-12.9 2.7-8.4 5.7-11.6 6.9-5.5 11.2-6.5 8.8-.7 13 .8c4.1 1.5 7.7 4.3 10.3 7.8 2.6 3.6 4.1 7.8 4.3 12.3.2 6-2 11.8-6.1 16.1-4.1 4.4-9.8 6.9-15.7 7.2"
-                      style="fill:#616262" />
-                    <path
-                      d="M256.3 386c-82 0-154.1-29.4-191.4-72.9 14.5 39.1 40.6 72.9 74.8 96.7s74.9 36.6 116.6 36.6 82.4-12.8 116.6-36.6 60.3-57.6 74.8-96.7c-37.2 43.5-109 72.9-191.4 72.9m0-282.7c82 0 154.1 29.4 191.4 72.9-14.5-39.1-40.6-72.9-74.8-96.7S298 42.9 256.3 42.9s-82.4 12.8-116.6 36.6-60.3 57.6-74.8 96.7c37.2-43.6 109-72.9 191.4-72.9"
-                      style="fill:#f37726" />
-                    <path
-                      d="M55.4 267.7c0 16-1.3 21.1-4.6 25-3.7 3.3-8.4 5.1-13.3 5.1l1.3 9.1c7.6.1 15-2.6 20.8-7.6 3.1-3.8 5.4-8.2 6.8-12.9s1.8-9.6 1.2-14.5v-60.3H55.4zm91.1-7.2c0 6.8 0 12.9.5 18.2h-10.8l-.7-10.8c-2.3 3.8-5.5 7-9.4 9.2s-8.3 3.3-12.7 3.2c-10.6 0-23.2-5.7-23.2-29.2v-38.9h12.2v36.5c0 12.7 3.9 21.1 14.9 21.1 2.3 0 4.5-.4 6.6-1.3s4-2.1 5.6-3.7 2.9-3.5 3.7-5.6c.9-2.1 1.3-4.4 1.3-6.6v-40.8h12.2v48.4zm23.1-26.6c0-8.5 0-15.4-.5-21.7H180l.5 11.4a26 26 0 0 1 10.2-9.8c4.2-2.3 9-3.4 13.7-3.2 16.2 0 28.4 13.6 28.4 33.8 0 23.9-14.7 35.7-30.5 35.7-4.1.2-8.1-.7-11.7-2.5s-6.7-4.6-9-8v36.5h-12zm12 17.8c0 1.7.2 3.3.5 4.9 1 4 3.4 7.6 6.7 10.2s7.4 3.9 11.5 3.9c12.9 0 20.4-10.5 20.4-25.7 0-13.3-7.1-24.7-20-24.7-5.1.4-9.8 2.7-13.4 6.3-3.5 3.7-5.6 8.5-5.8 13.6v11.5zm73-39.6 14.7 39.3c1.5 4.4 3.2 9.7 4.3 13.6 1.3-4 2.6-9.1 4.3-13.9l13.3-39H304l-18.2 47.4c-9.1 22.8-14.7 34.5-23.1 41.7-4.2 3.9-9.4 6.6-14.9 7.8l-3-10.2c3.9-1.3 7.5-3.3 10.7-5.9 4.4-3.6 8-8.2 10.3-13.5.5-.9.8-1.9 1-2.9-.1-1.1-.4-2.2-.8-3.2L241.2 212h13.3zm81.9-19.1v19.1H354v9.1h-17.5v35.9c0 8.2 2.4 12.9 9.1 12.9 2.4 0 4.8-.2 7.1-.8l.5 9.1c-3.5 1.2-7.2 1.8-10.8 1.6-2.4.2-4.9-.2-7.2-1.1s-4.3-2.2-6.1-4c-3.7-5-5.4-11.2-4.7-17.3V221H314v-9.1h10.6v-16.2zm40 54.6c-.2 3.1.2 6.2 1.3 9.1s2.8 5.6 5 7.7c2.2 2.2 4.8 3.9 7.7 5s6 1.5 9.1 1.3c6.3.1 12.5-1 18.2-3.5l2.1 9.1c-7.1 2.9-14.7 4.3-22.3 4.1-4.5.3-8.9-.4-13.1-1.9-4.2-1.6-8-4.1-11.1-7.2-3.1-3.2-5.5-7-7.1-11.2-1.5-4.2-2.1-8.7-1.7-13.1 0-20.1 11.9-35.9 31.4-35.9 21.9 0 27.3 19.1 27.3 31.4q.15 2.85 0 5.7h-47.1zm35.7-9.1c.4-2.4.2-4.9-.5-7.3s-1.9-4.6-3.5-6.4c-1.6-1.9-3.6-3.4-5.8-4.4s-4.7-1.6-7.1-1.6c-5 .4-9.7 2.6-13.2 6.2s-5.4 8.4-5.5 13.5zm29.7-5.6c0-7.8 0-14.6-.5-20.8h10.9v13h.5c1.1-4 3.5-7.6 6.8-10.2s7.3-4.1 11.4-4.4c1.1-.2 2.3-.2 3.5 0v11.4q-2.1-.3-4.2 0c-4.1.2-8.1 1.8-11.1 4.7s-4.9 6.7-5.2 10.8c-.3 1.9-.5 3.8-.5 5.7v35.5h-12V233z"
-                      style="fill:#4e4e4e" />
-                  </svg>Jupyter Lab</a></li>
-              <li><a href="./jupyter/tree" target="_blank"><svg xmlns="http://www.w3.org/2000/svg"
-                    xml:space="preserve" width="24" height="24" viewBox="0 0 512 512">
-                    <path
-                      d="M436.5 29c.4 6.1-1.1 12.2-4.2 17.5s-7.7 9.5-13.2 12.2-11.7 3.6-17.8 2.8c-6.1-.9-11.8-3.5-16.3-7.6-4.6-4.1-7.8-9.5-9.3-15.4-1.5-6-1.2-12.2.9-18S382.4 9.7 387.4 6s10.9-5.7 17-6c4-.2 8 .4 11.8 1.7s7.3 3.4 10.3 6.1 5.4 6 7.1 9.6c1.7 3.7 2.7 7.6 2.9 11.6"
-                      style="fill:#767677" />
-                    <path
-                      d="M143.3 470.7c.5 7.7-1.3 15.4-5.2 22.1s-9.7 12-16.7 15.4-14.8 4.6-22.4 3.5c-7.7-1.1-14.8-4.4-20.6-9.6-5.7-5.2-9.8-11.9-11.7-19.4s-1.5-15.4 1.1-22.7 7.3-13.6 13.5-18.2 13.7-7.2 21.4-7.6c5.1-.3 10.1.5 14.9 2.1 4.8 1.7 9.2 4.3 12.9 7.7 3.8 3.4 6.8 7.5 9 12.1 2.3 4.5 3.6 9.5 3.8 14.6"
-                      style="fill:#9e9e9e" />
-                    <path
-                      d="M74.2 93.4c-4.4.1-8.8-1.1-12.5-3.4s-6.7-5.8-8.5-9.8-2.4-8.5-1.7-12.9 2.7-8.4 5.7-11.6 6.9-5.5 11.2-6.5 8.8-.7 13 .8c4.1 1.5 7.7 4.3 10.3 7.8 2.6 3.6 4.1 7.8 4.3 12.3.2 6-2 11.8-6.1 16.1-4.1 4.4-9.8 6.9-15.7 7.2"
-                      style="fill:#616262" />
-                    <path
-                      d="M256.3 386c-82 0-154.1-29.4-191.4-72.9 14.5 39.1 40.6 72.9 74.8 96.7s74.9 36.6 116.6 36.6 82.4-12.8 116.6-36.6 60.3-57.6 74.8-96.7c-37.2 43.5-109 72.9-191.4 72.9m0-282.7c82 0 154.1 29.4 191.4 72.9-14.5-39.1-40.6-72.9-74.8-96.7S298 42.9 256.3 42.9s-82.4 12.8-116.6 36.6-60.3 57.6-74.8 96.7c37.2-43.6 109-72.9 191.4-72.9"
-                      style="fill:#f37726" />
-                    <path
-                      d="M55.4 267.7c0 16-1.3 21.1-4.6 25-3.7 3.3-8.4 5.1-13.3 5.1l1.3 9.1c7.6.1 15-2.6 20.8-7.6 3.1-3.8 5.4-8.2 6.8-12.9s1.8-9.6 1.2-14.5v-60.3H55.4zm91.1-7.2c0 6.8 0 12.9.5 18.2h-10.8l-.7-10.8c-2.3 3.8-5.5 7-9.4 9.2s-8.3 3.3-12.7 3.2c-10.6 0-23.2-5.7-23.2-29.2v-38.9h12.2v36.5c0 12.7 3.9 21.1 14.9 21.1 2.3 0 4.5-.4 6.6-1.3s4-2.1 5.6-3.7 2.9-3.5 3.7-5.6c.9-2.1 1.3-4.4 1.3-6.6v-40.8h12.2v48.4zm23.1-26.6c0-8.5 0-15.4-.5-21.7H180l.5 11.4a26 26 0 0 1 10.2-9.8c4.2-2.3 9-3.4 13.7-3.2 16.2 0 28.4 13.6 28.4 33.8 0 23.9-14.7 35.7-30.5 35.7-4.1.2-8.1-.7-11.7-2.5s-6.7-4.6-9-8v36.5h-12zm12 17.8c0 1.7.2 3.3.5 4.9 1 4 3.4 7.6 6.7 10.2s7.4 3.9 11.5 3.9c12.9 0 20.4-10.5 20.4-25.7 0-13.3-7.1-24.7-20-24.7-5.1.4-9.8 2.7-13.4 6.3-3.5 3.7-5.6 8.5-5.8 13.6v11.5zm73-39.6 14.7 39.3c1.5 4.4 3.2 9.7 4.3 13.6 1.3-4 2.6-9.1 4.3-13.9l13.3-39H304l-18.2 47.4c-9.1 22.8-14.7 34.5-23.1 41.7-4.2 3.9-9.4 6.6-14.9 7.8l-3-10.2c3.9-1.3 7.5-3.3 10.7-5.9 4.4-3.6 8-8.2 10.3-13.5.5-.9.8-1.9 1-2.9-.1-1.1-.4-2.2-.8-3.2L241.2 212h13.3zm81.9-19.1v19.1H354v9.1h-17.5v35.9c0 8.2 2.4 12.9 9.1 12.9 2.4 0 4.8-.2 7.1-.8l.5 9.1c-3.5 1.2-7.2 1.8-10.8 1.6-2.4.2-4.9-.2-7.2-1.1s-4.3-2.2-6.1-4c-3.7-5-5.4-11.2-4.7-17.3V221H314v-9.1h10.6v-16.2zm40 54.6c-.2 3.1.2 6.2 1.3 9.1s2.8 5.6 5 7.7c2.2 2.2 4.8 3.9 7.7 5s6 1.5 9.1 1.3c6.3.1 12.5-1 18.2-3.5l2.1 9.1c-7.1 2.9-14.7 4.3-22.3 4.1-4.5.3-8.9-.4-13.1-1.9-4.2-1.6-8-4.1-11.1-7.2-3.1-3.2-5.5-7-7.1-11.2-1.5-4.2-2.1-8.7-1.7-13.1 0-20.1 11.9-35.9 31.4-35.9 21.9 0 27.3 19.1 27.3 31.4q.15 2.85 0 5.7h-47.1zm35.7-9.1c.4-2.4.2-4.9-.5-7.3s-1.9-4.6-3.5-6.4c-1.6-1.9-3.6-3.4-5.8-4.4s-4.7-1.6-7.1-1.6c-5 .4-9.7 2.6-13.2 6.2s-5.4 8.4-5.5 13.5zm29.7-5.6c0-7.8 0-14.6-.5-20.8h10.9v13h.5c1.1-4 3.5-7.6 6.8-10.2s7.3-4.1 11.4-4.4c1.1-.2 2.3-.2 3.5 0v11.4q-2.1-.3-4.2 0c-4.1.2-8.1 1.8-11.1 4.7s-4.9 6.7-5.2 10.8c-.3 1.9-.5 3.8-.5 5.7v35.5h-12V233z"
-                      style="fill:#4e4e4e" />
-                  </svg>Jupyter (classic)</a></li>
-              {{- if $root.Values.applications.rstudio.enabled }}
-              <li><a href="./rstudio/" target="_blank"><svg xmlns="http://www.w3.org/2000/svg" width="24"
-                    height="24" viewBox="0 0 128 128">
-                    <path fill="#75aadb"
-                      d="M71.4 38.8c-1.5-.6-3.9-1-6.9-1.1-4.2-.1-9 .4-9.2.5v20c13.3.6 15.5-1.7 15.5-1.7 11.6-5.9 4.3-16.2.6-17.7z" />
-                    <path fill="#75aadb"
-                      d="M64 0C28.6 0 0 28.6 0 64s28.6 64 64 64 64-28.6 64-64S99.3 0 64 0zm28.6 89.8H82L64.4 63.5h-9V84h9v5.8H41.5v-5.7l7.6-.1-.1-45.9c-.8-.2-7.5-.8-7.5-.8V32c1 1 7.9 1.2 7.9 1.2 1.6.1 3.9.2 5.2-.1 9.3-1.7 16.4-.4 16.4-.4 14 3.2 14.2 15.8 10.3 22.6-3.5 5.8-10.3 7.2-10.3 7.2l14.4 21.8 7.2-.1v5.6z" />
-                    <path
-                      d="M41.595 87.073v-2.726l1.82-.141a59.125 59.125 0 013.752-.144h1.931V37.996l-.938-.127c-.516-.07-2.204-.248-3.752-.397l-2.813-.27v-2.51c0-2.332.027-2.495.39-2.3 1.583.847 10.7 1.07 15.83.388 4.202-.558 11.495-.425 14.035.257 5.483 1.472 9.11 4.646 10.824 9.473.717 2.018.817 5.847.216 8.224-.903 3.572-2.39 6.048-4.865 8.101-1.482 1.23-4.847 3.03-6.145 3.29-.397.079-.772.224-.832.321-.06.098 3.123 5.072 7.075 11.054l7.184 10.876 3.633-.068 3.634-.068V89.8l-5.242-.008-5.24-.007-8.82-13.234-8.817-13.234h-9.178V84.061h9.049V89.8H41.595zm25.158-29.162c3.476-.55 7.265-2.774 8.973-5.263 2.511-3.663 1.537-8.99-2.294-12.547-1.357-1.26-2.205-1.63-4.794-2.1-2.124-.386-8.66-.454-11.706-.122l-1.544.168-.058 10.083-.057 10.082.72.106c1.366.2 8.67-.075 10.76-.407z"
-                      fill="#fff" stroke="#fff" stroke-width=".788" />
-                  </svg>R-Studio</a></li>
-              {{- end }}
-            </ul>
-          </article>
-          <article>
-            <h4>Applications</h4>
-            <ul>
-              <li><a href="./airflow/" target="_blank"><svg width="24" height="24" viewBox="0 0 128 128"
-                    xmlns="http://www.w3.org/2000/svg">
-                    <path
-                      d="m2.5441 127 60.809-62.332a1.124 1.124 0 0 0 0.1359-1.4368c-3.6977-5.1625-10.521-6.0578-13.05-9.5268-7.4903-10.275-9.3909-16.092-12.61-15.731a0.98374 0.98374 0 0 0-0.58464 0.3085l-21.966 22.518c-12.638 12.944-14.454 41.475-14.782 65.367a1.1908 1.1908 0 0 0 2.0473 0.83273z"
-                      fill="#017cee" />
-                    <path
-                      d="m126.99 125.46-62.332-60.813a1.124 1.124 0 0 0-1.4389-0.1359c-5.1625 3.6998-6.0578 10.521-9.5268 13.05-10.275 7.4903-16.092 9.3909-15.731 12.61a0.98374 0.98374 0 0 0 0.3085 0.58248l22.518 21.966c12.944 12.638 41.475 14.454 65.367 14.782a1.1908 1.1908 0 0 0 0.83489-2.0408z"
-                      fill="#00ad46" />
-                    <path
-                      d="m60.792 112.72c-7.076-6.9035-10.355-20.559 3.2058-48.719-22.046 9.8525-29.771 22.803-25.972 26.511z"
-                      fill="#04d659" />
-                    <path
-                      d="m125.45 1.0113-60.807 62.332a1.1218 1.1218 0 0 0-0.1359 1.4368c3.6998 5.1625 10.519 6.0578 13.05 9.5268 7.4903 10.275 9.393 16.092 12.61 15.731a0.97943 0.97943 0 0 0 0.58464-0.3085l21.966-22.518c12.638-12.944 14.454-41.475 14.782-65.367a1.193 1.193 0 0 0-2.0495-0.83273z"
-                      fill="#00c7d4" />
-                    <path
-                      d="m112.73 67.211c-6.9035 7.076-20.559 10.355-48.721-3.2058 9.8525 22.046 22.803 29.771 26.511 25.972z"
-                      fill="#11e1ee" />
-                    <path
-                      d="m1.0017 2.5495 62.332 60.807a1.124 1.124 0 0 0 1.4368 0.1359c5.1625-3.6998 6.0578-10.521 9.5268-13.05 10.275-7.4903 16.092-9.3909 15.731-12.61a0.99022 0.99022 0 0 0-0.3085-0.58463l-22.518-21.966c-12.944-12.638-41.475-14.454-65.367-14.782a1.1908 1.1908 0 0 0-0.83273 2.0495z"
-                      fill="#e43921" />
-                    <path
-                      d="m67.212 15.284c7.076 6.9035 10.355 20.559-3.2058 48.721 22.046-9.8525 29.771-22.805 25.972-26.511z"
-                      fill="#ff7557" />
-                    <path
-                      d="m15.279 60.8c6.9035-7.076 20.559-10.355 48.721 3.2058-9.8525-22.046-22.803-29.771-26.511-25.972z"
-                      fill="#0cb6ff" />
-                    <circle cx="64.009" cy="63.995" r="2.7182" fill="#4a4848" />
-                  </svg>Airflow</a></li>
-              <li><a href="./mlflow/" target="_blank"><svg role="img" width="24" height="24" viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg">
-                    <title>MLflow</title>
-                    <path
-                      d="M11.883.002a12.044 12.044 0 0 0-9.326 19.463l3.668-2.694A7.573 7.573 0 0 1 12.043 4.45v2.867l6.908-5.14A12.012 12.012 0 0 0 11.883.002zm9.562 4.533L17.777 7.23a7.573 7.573 0 0 1-5.818 12.322v-2.867l-6.908 5.14a12.046 12.046 0 0 0 16.394-17.29z" />
-                  </svg>MLflow</a></li>
-            </ul>
-          </article>
-          <article>
-            <h4>Other</h4>
-            <ul>
-              <li><a href="./browser/" target="_blank"><svg xmlns="http://www.w3.org/2000/svg"
-                    xml:space="preserve" width="24" height="24" viewBox="0 0 512 512">
-                    <linearGradient id="firefox_svg__a" x1="472.337" x2="52.763" y1="358.518" y2="763.335"
-                      gradientTransform="translate(-2.52 -266.419)scale(.9643)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset=".048" style="stop-color:#fff44f" />
-                      <stop offset=".111" style="stop-color:#ffe847" />
-                      <stop offset=".225" style="stop-color:#ffc830" />
-                      <stop offset=".368" style="stop-color:#ff980e" />
-                      <stop offset=".401" style="stop-color:#ff8b16" />
-                      <stop offset=".462" style="stop-color:#ff672a" />
-                      <stop offset=".534" style="stop-color:#ff3647" />
-                      <stop offset=".705" style="stop-color:#e31587" />
-                    </linearGradient>
-                    <path
-                      d="M485.9 171.9c-10.8-25.9-32.7-54-49.8-62.8 12.2 23.7 20.7 49.1 25.1 75.3v.4c-28.1-69.9-75.6-98.2-114.5-159.6-2-3.1-3.9-6.2-5.9-9.5-1.1-1.9-2-3.5-2.7-5.1-1.6-3.1-2.8-6.4-3.7-9.8 0-.3-.2-.6-.6-.7h-.5l-.1.1s-.1.1-.2.1l.1-.2c-62.4 36.5-83.5 104.1-85.4 137.9-24.9 1.7-48.7 10.9-68.3 26.3-2.1-1.8-4.2-3.3-6.4-4.8-5.7-19.8-5.9-40.8-.7-60.7a183.2 183.2 0 0 0-59.7 46.2h-.1c-9.8-12.5-9.1-53.6-8.5-62.2-2.9 1.2-5.7 2.7-8.2 4.4-8.8 6.1-16.9 13.1-24.4 20.8-8.5 8.6-16.3 18-23.2 27.8-15.9 22.6-27.3 48.1-33.3 75.2l-.3 1.7c-.5 2.2-2.2 13.2-2.5 15.5 0 .2 0 .4-.1.6-2.2 11.3-3.5 22.7-4 34.2v1.3c.2 137.1 111.6 248 248.6 247.8 120.6-.2 223.6-87 244.1-205.8.4-3.2.8-6.4 1.1-9.6 5.3-42.4-.2-85.2-15.9-124.8M199.8 366.2c1.2.6 2.3 1.2 3.4 1.7l.2.1q-1.65-.9-3.6-1.8m261.5-181.3v-.2z"
-                      style="fill:url(#firefox_svg__a)" />
-                    <radialGradient id="firefox_svg__b" cx="-7665.701" cy="-8344.235" r="526.888"
-                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset=".129" style="stop-color:#ffbd4f" />
-                      <stop offset=".186" style="stop-color:#ffac31" />
-                      <stop offset=".247" style="stop-color:#ff9d17" />
-                      <stop offset=".283" style="stop-color:#ff980e" />
-                      <stop offset=".403" style="stop-color:#ff563b" />
-                      <stop offset=".467" style="stop-color:#ff3750" />
-                      <stop offset=".71" style="stop-color:#f5156c" />
-                      <stop offset=".782" style="stop-color:#eb0878" />
-                      <stop offset=".86" style="stop-color:#e50080" />
-                    </radialGradient>
-                    <path
-                      d="M485.9 171.9c-10.8-25.9-32.7-54-49.8-62.8 12.2 23.7 20.7 49.1 25.1 75.3v.5c19.1 54.7 16.4 114.8-7.8 167.5-28.5 61.1-97.3 123.6-205 120.5C132 469.6 29.4 383.1 10.3 270c-3.5-17.9 0-26.9 1.8-41.4-2.4 11.3-3.7 22.7-4 34.3v1.3c.2 137.1 111.6 248 248.6 247.8 120.7-.1 223.6-86.9 244.2-205.7.4-3.2.8-6.4 1.1-9.6 5.1-42.4-.4-85.2-16.1-124.8"
-                      style="fill:url(#firefox_svg__b)" />
-                    <radialGradient id="firefox_svg__c" cx="-7864.917" cy="-8125.098" r="526.888"
-                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset=".3" style="stop-color:#960e18" />
-                      <stop offset=".351" style="stop-color:#b11927;stop-opacity:.74" />
-                      <stop offset=".435" style="stop-color:#db293d;stop-opacity:.343" />
-                      <stop offset=".497" style="stop-color:#f5334b;stop-opacity:9.400000e-02" />
-                      <stop offset=".53" style="stop-color:#ff3750;stop-opacity:0" />
-                    </radialGradient>
-                    <path
-                      d="M485.9 171.9c-10.8-25.9-32.7-54-49.8-62.8 12.2 23.7 20.7 49.1 25.1 75.3v.5c19.1 54.7 16.4 114.8-7.8 167.5-28.5 61.1-97.3 123.6-205 120.5C132 469.6 29.4 383.1 10.3 270c-3.5-17.9 0-26.9 1.8-41.4-2.4 11.3-3.7 22.7-4 34.3v1.3c.2 137.1 111.6 248 248.6 247.8 120.7-.1 223.6-86.9 244.2-205.7.4-3.2.8-6.4 1.1-9.6 5.1-42.4-.4-85.2-16.1-124.8"
-                      style="fill:url(#firefox_svg__c)" />
-                    <radialGradient id="firefox_svg__d" cx="-7798.511" cy="-8463.765" r="381.667"
-                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset=".132" style="stop-color:#fff44f" />
-                      <stop offset=".252" style="stop-color:#ffdc3e" />
-                      <stop offset=".506" style="stop-color:#ff9d12" />
-                      <stop offset=".526" style="stop-color:#ff980e" />
-                    </radialGradient>
-                    <path
-                      d="M365.3 201c.5.4 1.1.8 1.6 1.2-6.2-11.1-14-21.2-23.1-30C266.6 95 323.6 4.8 333.1.2l.1-.1c-62.4 36.5-83.5 104.1-85.4 137.9 2.8-.2 5.8-.4 8.7-.4 45.1 0 86.6 24.3 108.8 63.4"
-                      style="fill:url(#firefox_svg__d)" />
-                    <radialGradient id="firefox_svg__e" cx="-7924.681" cy="-7985.648" r="250.858"
-                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset=".353" style="stop-color:#3a8ee6" />
-                      <stop offset=".472" style="stop-color:#5c79f0" />
-                      <stop offset=".669" style="stop-color:#9059ff" />
-                      <stop offset="1" style="stop-color:#c139e6" />
-                    </radialGradient>
-                    <path
-                      d="M256.7 216.5c-.4 6.2-22.2 27.5-29.9 27.5-70.6 0-82 42.7-82 42.7 3.1 35.9 28.2 65.6 58.4 81.2 1.4.7 2.7 1.4 4.2 2 2.5 1.1 4.8 2.1 7.3 2.9 10.4 3.6 21.3 5.8 32.3 6.2 123.7 5.8 147.7-147.9 58.4-192.6 21-2.7 42.4 2.5 59.8 14.5-22.2-39.2-63.7-63.4-108.7-63.5-2.9 0-5.8.2-8.7.4-24.9 1.7-48.7 10.9-68.3 26.3 3.8 3.2 8.1 7.5 17.1 16.3 16.8 16.8 60 34 60.1 36.1"
-                      style="fill:url(#firefox_svg__e)" />
-                    <radialGradient id="firefox_svg__f" cx="-7965.277" cy="-8188.533" r="133.026"
-                      gradientTransform="matrix(.9373 -.2266 .2651 1.0974 9907.315 7405.453)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset=".206" style="stop-color:#9059ff;stop-opacity:0" />
-                      <stop offset=".278" style="stop-color:#8c4ff3;stop-opacity:6.400000e-02" />
-                      <stop offset=".747" style="stop-color:#7716a8;stop-opacity:.45" />
-                      <stop offset=".975" style="stop-color:#6e008b;stop-opacity:.6" />
-                    </radialGradient>
-                    <path
-                      d="M256.7 216.5c-.4 6.2-22.2 27.5-29.9 27.5-70.6 0-82 42.7-82 42.7 3.1 35.9 28.2 65.6 58.4 81.2 1.4.7 2.7 1.4 4.2 2 2.5 1.1 4.8 2.1 7.3 2.9 10.4 3.6 21.3 5.8 32.3 6.2 123.7 5.8 147.7-147.9 58.4-192.6 21-2.7 42.4 2.5 59.8 14.5-22.2-39.2-63.7-63.4-108.7-63.5-2.9 0-5.8.2-8.7.4-24.9 1.7-48.7 10.9-68.3 26.3 3.8 3.2 8.1 7.5 17.1 16.3 16.8 16.8 60 34 60.1 36.1"
-                      style="fill:url(#firefox_svg__f)" />
-                    <radialGradient id="firefox_svg__g" cx="-7871.557" cy="-8364.156" r="180.498"
-                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset="0" style="stop-color:#ffe226" />
-                      <stop offset=".121" style="stop-color:#ffdb27" />
-                      <stop offset=".295" style="stop-color:#ffc82a" />
-                      <stop offset=".502" style="stop-color:#ffa930" />
-                      <stop offset=".732" style="stop-color:#ff7e37" />
-                      <stop offset=".792" style="stop-color:#ff7139" />
-                    </radialGradient>
-                    <path
-                      d="M167.9 156.1c2 1.3 3.6 2.4 5.1 3.4-5.7-19.8-5.9-40.8-.7-60.7a183.2 183.2 0 0 0-59.7 46.2c1.2 0 37.3-.7 55.3 11.1"
-                      style="fill:url(#firefox_svg__g)" />
-                    <radialGradient id="firefox_svg__h" cx="-7725.465" cy="-8483.686" r="770.116"
-                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset=".113" style="stop-color:#fff44f" />
-                      <stop offset=".456" style="stop-color:#ff980e" />
-                      <stop offset=".622" style="stop-color:#ff5634" />
-                      <stop offset=".716" style="stop-color:#ff3647" />
-                      <stop offset=".904" style="stop-color:#e31587" />
-                    </radialGradient>
-                    <path
-                      d="M10.3 270.1C29.5 383.2 132.1 469.7 248.5 473c107.7 3 176.6-59.5 205-120.5 24.1-52.7 26.8-112.7 7.8-167.5v-.4.4c8.8 57.4-20.4 113.1-66.2 150.8l-.1.3c-89.1 72.6-174.3 43.8-191.5 32-1.2-.6-2.5-1.2-3.6-1.8-51.9-24.8-73.4-72.1-68.7-112.7-25.1.4-48.2-14.1-58.8-37 27.7-17 62.3-18.4 91.2-3.6 29.4 13.4 62.8 14.6 93.2 3.6-.1-2.1-43.3-19.2-60.1-35.8-9-8.8-13.3-13.2-17.1-16.3-2.1-1.8-4.2-3.3-6.4-4.8-1.5-1-3.1-2.1-5.1-3.4-18.1-11.8-54.1-11.1-55.3-11.1h-.1c-9.8-12.5-9.1-53.6-8.5-62.2-2.9 1.2-5.7 2.7-8.2 4.4-8.6 6.2-16.8 13.2-24.3 20.8-8.5 8.5-16.3 17.9-23.3 27.8-16 22.5-27.4 48.1-33.4 75.2-.3.4-9 38.9-4.7 58.9"
-                      style="fill:url(#firefox_svg__h)" />
-                    <radialGradient id="firefox_svg__i" cx="-7876.41" cy="-9224.912" r="564.057"
-                      gradientTransform="matrix(.1012 .9595 -.6296 .06654 -4694.67 8136.184)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset="0" style="stop-color:#fff44f" />
-                      <stop offset=".06" style="stop-color:#ffe847" />
-                      <stop offset=".168" style="stop-color:#ffc830" />
-                      <stop offset=".304" style="stop-color:#ff980e" />
-                      <stop offset=".356" style="stop-color:#ff8b16" />
-                      <stop offset=".455" style="stop-color:#ff672a" />
-                      <stop offset=".57" style="stop-color:#ff3647" />
-                      <stop offset=".737" style="stop-color:#e31587" />
-                    </radialGradient>
-                    <path
-                      d="M343.8 172.1c9 8.9 16.8 19.1 23.1 30 1.4 1 2.7 2.1 3.7 3 56.3 51.8 26.8 125.2 24.5 130.4 45.7-37.6 74.9-93.3 66.1-150.8-28.1-70-75.7-98.2-114.5-159.7-2-3.1-3.9-6.2-5.9-9.5-1.1-1.9-2-3.5-2.7-5.1-1.6-3.1-2.8-6.4-3.7-9.8 0-.3-.2-.6-.6-.7h-.5l-.1.1s-.1.1-.2.1c-9.6 4.5-66.6 94.7 10.6 171.8z"
-                      style="fill:url(#firefox_svg__i)" />
-                    <radialGradient id="firefox_svg__j" cx="-7871.557" cy="-8297.752" r="480.72"
-                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset=".137" style="stop-color:#fff44f" />
-                      <stop offset=".48" style="stop-color:#ff980e" />
-                      <stop offset=".592" style="stop-color:#ff5634" />
-                      <stop offset=".655" style="stop-color:#ff3647" />
-                      <stop offset=".904" style="stop-color:#e31587" />
-                    </radialGradient>
-                    <path
-                      d="M370.5 205.3c-1.1-1-2.4-2.1-3.7-3-.5-.4-1-.8-1.6-1.2-17.5-12.1-38.8-17.3-59.8-14.5 89.3 44.7 65.3 198.4-58.4 192.6-11-.5-21.9-2.6-32.3-6.2-2.5-.9-4.8-1.9-7.3-2.9-1.4-.7-2.8-1.3-4.2-2l.2.1c17.3 11.8 102.4 40.6 191.5-32l.1-.3c2.3-5.4 31.8-78.7-24.5-130.6"
-                      style="fill:url(#firefox_svg__j)" />
-                    <radialGradient id="firefox_svg__k" cx="-7745.387" cy="-8271.19" r="526.17"
-                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset=".094" style="stop-color:#fff44f" />
-                      <stop offset=".231" style="stop-color:#ffe141" />
-                      <stop offset=".509" style="stop-color:#ffaf1e" />
-                      <stop offset=".626" style="stop-color:#ff980e" />
-                    </radialGradient>
-                    <path
-                      d="M144.8 286.6s11.5-42.7 82-42.7c7.7 0 29.5-21.3 29.9-27.5-30.3 11-63.8 9.7-93.2-3.6-29-14.7-63.5-13.4-91.2 3.6 10.6 22.9 33.6 37.3 58.8 37-4.6 40.6 16.9 87.9 68.7 112.7 1.2.6 2.3 1.2 3.4 1.7-30.3-15.6-55.3-45.3-58.4-81.2"
-                      style="fill:url(#firefox_svg__k)" />
-                    <linearGradient id="firefox_svg__l" x1="467.354" x2="110.401" y1="356.528" y2="713.547"
-                      gradientTransform="translate(-2.52 -266.419)scale(.9643)"
-                      gradientUnits="userSpaceOnUse">
-                      <stop offset=".167" style="stop-color:#fff44f;stop-opacity:.8" />
-                      <stop offset=".266" style="stop-color:#fff44f;stop-opacity:.634" />
-                      <stop offset=".489" style="stop-color:#fff44f;stop-opacity:.217" />
-                      <stop offset=".6" style="stop-color:#fff44f;stop-opacity:0" />
-                    </linearGradient>
-                    <path
-                      d="M485.9 171.9c-10.8-25.9-32.7-54-49.8-62.8 12.2 23.7 20.7 49.1 25.1 75.3v.4c-28.1-69.9-75.6-98.2-114.5-159.6-2-3.1-3.9-6.2-5.9-9.5-1.1-1.9-2-3.5-2.7-5.1-1.6-3.1-2.8-6.4-3.7-9.8 0-.3-.2-.6-.6-.7h-.5l-.1.1s-.1.1-.2.1l.1-.2c-62.4 36.5-83.5 104.1-85.4 137.9 2.8-.2 5.8-.4 8.7-.4 45 .1 86.5 24.4 108.7 63.5-17.5-12.1-38.8-17.3-59.8-14.5 89.3 44.7 65.3 198.4-58.4 192.6-11-.5-21.9-2.6-32.3-6.2-2.5-.9-4.8-1.9-7.3-2.9-1.4-.7-2.8-1.3-4.2-2l.2.1c-1.2-.6-2.5-1.2-3.6-1.8 1.2.6 2.3 1.2 3.4 1.7-30.3-15.7-55.3-45.3-58.4-81.2 0 0 11.5-42.7 82-42.7 7.7 0 29.5-21.3 29.9-27.5-.1-2.1-43.3-19.2-60.1-35.8-9-8.8-13.3-13.2-17.1-16.3-2.1-1.8-4.2-3.3-6.4-4.8-5.7-19.8-5.9-40.8-.7-60.7a183.2 183.2 0 0 0-59.7 46.2h.1c-9.8-12.5-9.1-53.6-8.5-62.2-2.9 1.2-5.7 2.7-8.2 4.4-8.6 6.2-16.8 13.2-24.3 20.8-8.5 8.6-16.3 18-23.2 27.8-15.9 22.6-27.3 48.1-33.3 75.2l-.3 1.7c-.5 2.2-2.6 13.3-2.8 15.6-2 11.5-3.1 23-3.6 34.6v1.3C8.6 401.4 119.9 512.2 257 512c120.6-.2 223.5-87 244.1-205.8.4-3.2.8-6.4 1.1-9.6 4.9-42.2-.6-85.1-16.3-124.7m-24.7 12.7v.3z"
-                      style="fill:url(#firefox_svg__l)" />
-                  </svg>Firefox</a></li>
-              <li><a href="https://analyticsldt.atlassian.net/wiki/spaces/EED/pages/3026288727/DataOps"
-                  target="_blank"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                    viewBox="0 0 128 128">
-                    <defs>
-                      <linearGradient id="confluence-original-a" gradientUnits="userSpaceOnUse"
-                        x1="26.791" y1="28.467" x2="11.792" y2="19.855" gradientTransform="scale(4)">
-                        <stop offset="0" stop-color="#0052cc" />
-                        <stop offset=".918" stop-color="#2380fb" />
-                        <stop offset="1" stop-color="#2684ff" />
-                      </linearGradient>
-                      <linearGradient id="confluence-original-b" gradientUnits="userSpaceOnUse" x1="5.209"
-                        y1="2.523" x2="20.208" y2="11.136" gradientTransform="scale(4)">
-                        <stop offset="0" stop-color="#0052cc" />
-                        <stop offset=".918" stop-color="#2380fb" />
-                        <stop offset="1" stop-color="#2684ff" />
-                      </linearGradient>
-                    </defs>
-                    <path
-                      d="M19.492 86.227a249.047 249.047 0 00-3.047 4.933c-.867 1.45-.433 3.336 1.016 4.207l19.863 12.188c1.45.87 3.332.433 4.203-1.016a139.349 139.349 0 012.899-4.934c7.832-12.91 15.804-11.46 30.011-4.64l19.72 9.281c1.593.727 3.335 0 4.058-1.45l9.426-21.323c.722-1.453 0-3.336-1.454-4.063-4.203-1.887-12.464-5.805-19.714-9.43-26.82-12.914-49.586-12.043-66.98 16.247zm0 0"
-                      fill="url(#confluence-original-a)" />
-                    <path
-                      d="M108.508 37.773a249.047 249.047 0 003.047-4.933c.87-1.45.433-3.336-1.016-4.207L90.676 16.445c-1.45-.87-3.332-.433-4.203 1.016a133.55 133.55 0 01-2.899 4.934c-7.832 12.91-15.804 11.46-30.011 4.64l-19.72-9.281c-1.593-.727-3.331 0-4.058 1.45l-9.422 21.323c-.726 1.453 0 3.34 1.45 4.063 4.203 1.887 12.468 5.805 19.714 9.43 26.825 12.77 49.586 12.042 66.98-16.247zm0 0"
-                      fill="url(#confluence-original-b)" />
-                  </svg>Confluence</a></li>
-            </ul>
-          </article>
-        </div>
-        <hr />
-        <h3>Instructions</h3>
-        <h4>Mlflow</h4>
-        <p>
-          Tracking URI for cluster internal use: <a>http://shared-space:5000</a>
-        </p>
-        <h4>SSH Tunnel</h4>
-        <p>
-          Download <a href="{{ $root.Values.ssh.clientDownloadLink }}">ws-tunnel</a> and execute:
-        </p>
-        <p>
-          <kbd>ws-tunnel wss://{{ $root.Values.ingress.host }}/{{lower .username}}/ssh</kbd>
-        </p>
-        <p>
-          Then connect to the port exposed:
-        </p>
-        <p>
-          <kbd>ssh {{lower .username}}@localhost -p EXPOSED_PORT</kbd>
-        </p>
-      </main>
-      <script>
-        function switchTheme(e) {
-          if (document.documentElement.getAttribute('data-theme') == 'light') {
-            document.documentElement.setAttribute('data-theme', 'dark')
-            document.querySelector('#theme-switcher svg').classList.remove('moon')
-          } else {
-            document.documentElement.setAttribute('data-theme', 'light')
-            document.querySelector('#theme-switcher svg').classList.add('moon')
-          }
-        }
-        function onLoad() {
-          let bt = document.getElementById('theme-switcher')
-          bt.addEventListener('click', switchTheme)
-        }
-        onLoad();
-      </script>
+    
+    	<header>
+    		<nav>
+    			<ul>
+    				<li>
+    					<h2>Welcome, {{lower .username}}!</h2>
+    				</li>
+    			</ul>
+    			<ul>
+    				<li><a href="/" class="contrast" style="text-decoration-style: wavy;">Controller</a></li>
+    				<li><a href="#" id="theme-switcher" class="contrast"><svg xmlns="http://www.w3.org/2000/svg" width="24"
+    							height="24" viewBox="0 0 32 32" fill="currentColor" class="icon-theme-toggle theme-toggle">
+    							<clipPath id="theme-toggle-cutout">
+    								<path d="M0-11h25a1 1 0 0017 13v30H0Z"></path>
+    							</clipPath>
+    							<g clip-path="url(#theme-toggle-cutout)">
+    								<circle cx="16" cy="16" r="8.4"></circle>
+    								<path
+    									d="M18.3 3.2c0 1.3-1 2.3-2.3 2.3s-2.3-1-2.3-2.3S14.7.9 16 .9s2.3 1 2.3 2.3zm-4.6 25.6c0-1.3 1-2.3 2.3-2.3s2.3 1 2.3 2.3-1 2.3-2.3 2.3-2.3-1-2.3-2.3zm15.1-10.5c-1.3 0-2.3-1-2.3-2.3s1-2.3 2.3-2.3 2.3 1 2.3 2.3-1 2.3-2.3 2.3zM3.2 13.7c1.3 0 2.3 1 2.3 2.3s-1 2.3-2.3 2.3S.9 17.3.9 16s1-2.3 2.3-2.3zm5.8-7C9 7.9 7.9 9 6.7 9S4.4 8 4.4 6.7s1-2.3 2.3-2.3S9 5.4 9 6.7zm16.3 21c-1.3 0-2.3-1-2.3-2.3s1-2.3 2.3-2.3 2.3 1 2.3 2.3-1 2.3-2.3 2.3zm2.4-21c0 1.3-1 2.3-2.3 2.3S23 7.9 23 6.7s1-2.3 2.3-2.3 2.4 1 2.4 2.3zM6.7 23C8 23 9 24 9 25.3s-1 2.3-2.3 2.3-2.3-1-2.3-2.3 1-2.3 2.3-2.3z">
+    								</path>
+    							</g>
+    						</svg></a></li>
+    			</ul>
+    		</nav>
+    	</header>
+    	<main>
+    		<h3>Tools</h3>
+    		<div class="grid">
+    			<article>
+    				<h4>IDEs</h4>
+    				<ul>
+    					<li><a href="./code/" target="_blank">Code</a></li>
+    					<li><a href="./jupyter/" target="_blank">Jupyter Lab</a></li>
+    					<li><a href="./jupyter/tree" target="_blank">Jupyter</a></li>
+    					{{- if $root.Values.applications.rstudio.enabled }}
+    					<li><a href="./rstudio/" target="_blank">R-Studio</a></li>
+    					{{- end }}
+    				</ul>
+    			</article>
+    			<article>
+    				<h4>Applications</h4>
+    				<ul>
+    					<li><a href="./airflow/" target="_blank">Airflow</a></li>
+    					<li><a href="./mlflow/" target="_blank">MLflow</a></li>
+    				</ul>
+    			</article>
+    			<article>
+    				<h4>Other</h4>
+    				<ul>
+    					<li><a href="./browser/" target="_blank">Firefox</a></li>
+    					<li><a href="https://analyticsldt.atlassian.net/wiki/spaces/EED/pages/3026288727/DataOps" target="_blank">Confluence DataOps</a></li>
+              <li><a href="https://grafana.dev.raizen.ai/" target="_blank">Grafana DEV</a></li>
+    				</ul>
+    			</article>
+    		</div>
+    		<hr />
+    		<h3>Instructions</h3>
+    		<h4>Mlflow</h4>
+    		<p>
+    			Tracking URI for cluster internal use: <a>http://shared-space:5000</a>
+    		</p>
+    		<h4>SSH Tunnel</h4>
+    		<p>
+    			Download <a href="{{ $root.Values.ssh.clientDownloadLink }}" target="_blank">ws-tunnel</a> and execute:
+    		</p>
+    		<p>
+    			<kbd>ws-tunnel wss://{{ $root.Values.ingress.host }}/{{lower .username}}/ssh</kbd>
+    		</p>
+    		<p>
+    			Then connect to the port exposed:
+    		</p>
+    		<p>
+    			<kbd>ssh {{lower .username}}@localhost -p EXPOSED_PORT</kbd>
+    		</p>
+    	</main>
+    
+    	<script>
+    		function switchTheme(e) {
+    			if (document.documentElement.getAttribute('data-theme') == 'light') {
+    				document.documentElement.setAttribute('data-theme', 'dark')
+    				document.querySelector('#theme-switcher svg').classList.remove('moon')
+    			} else {
+    				document.documentElement.setAttribute('data-theme', 'light')
+    				document.querySelector('#theme-switcher svg').classList.add('moon')
+    			}
+    		}
+    
+    		function onLoad() {
+    			let bt = document.getElementById('theme-switcher')
+    			bt.addEventListener('click', switchTheme)
+    		}
+    
+    		onLoad();
+    	</script>
     </body>
+
 {{- end }}

--- a/developer-env/templates/configmaps/user-apps-html.yaml
+++ b/developer-env/templates/configmaps/user-apps-html.yaml
@@ -165,7 +165,7 @@ data:
     	</main>
     
     	<script>
-    		function setTheme(theme) {
+        function setTheme(theme) {
           if (!theme) return;
           localStorage.setItem('user-theme', theme)
           document.documentElement.setAttribute('data-theme', theme)
@@ -175,19 +175,19 @@ data:
             document.querySelector('#theme-switcher svg').classList.remove('moon')
           }
         }
-    		function toggleTheme(e) {
-    			if (document.documentElement.getAttribute('data-theme') == 'light') {
-    				setTheme('dark')
-    			} else {
-    				setTheme('light')
-    			}
-    		}
-    		function onLoad() {
+        function toggleTheme(e) {
+          if (document.documentElement.getAttribute('data-theme') == 'light') {
+            setTheme('dark')
+          } else {
+            setTheme('light')
+          }
+        }
+        function onLoad() {
           setTheme(localStorage.getItem('user-theme'))
-    			let bt = document.getElementById('theme-switcher')
-    			bt.addEventListener('click', toggleTheme)
-    		}
-    		onLoad();
+          let bt = document.getElementById('theme-switcher')
+          bt.addEventListener('click', toggleTheme)
+        }
+        onLoad();
     	</script>
     </body>
 

--- a/developer-env/templates/configmaps/user-apps-html.yaml
+++ b/developer-env/templates/configmaps/user-apps-html.yaml
@@ -11,55 +11,453 @@ data:
   index.html: |
     <!DOCTYPE html>
     <head>
+      <title>DEV</title>
       <meta charset="UTF-8">
-    </head>
-    <body>
-      <h2>Tools</h2>
-      <ul>
-        <li><a href="./code/">Code</a></li>
-        <li><a href="./jupyter/">JupyterLab</a></li>
-        <li><a href="./jupyter/tree">Jupyter (classic)</a></li>
-        {{- if $root.Values.applications.rstudio.enabled }}
-        <li><a href="./rstudio/">R-Studio</a></li>
-        {{- end }}
-        <li><a href="/">Controlador de Ambiente</a></li>
-      </ul>
-      <h2>Applications</h2>
-      <ul>
-        <li><a href="/airflow/">Airflow</a></li>
-        <li><a href="/mlflow/">Mlflow</a></li>
-      </ul>
-      <h2>Other</h2>
-      <ul>
-        <li><a href="./browser/">Firefox</a></li>
-        <li><a href="https://analyticsldt.atlassian.net/wiki/spaces/EED/pages/3026288727/DataOps">Confluence de DataOPS</a></li>
-      </ul>
-      <h2>Instructions</h2>
-      <h3>Mlflow</h3>
-      <p>
-        Tracking URI for cluster internal use: http://shared-space:5000
-      </p>
-      <h3>SSH (Experimental)</h3>
-      <p>
-        Download <a href="{{ $root.Values.ssh.clientDownloadLink }}">ws-tunnel</a> and execute: ws-tunnel wss://{{ $root.Values.ingress.host }}/{{lower .username}}/ssh
-      </p>
-      <p>
-        Then connect to the port exposed: ssh {{lower .username}}@localhost -p EXPOSED_PORT
-      </p>
-      <script>
-        function onLoad(){
-          fetch("./password").then(function(response) {
-            response.text().then(function(password){
-              document.getElementById('password').value = password;
-            })
-          });
+      <link rel="icon"
+        href="data:image/svg+xml,%3Csvg width='800px' height='800px' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3E%0Apath %7B fill: %2360903e; %7D%0A@media (prefers-color-scheme: dark) %7B%0Apath %7B fill: %23acd36c; %7D%0A%7D%0A.booster %7B stroke: %23f57c00; %7D%0A%3C/style%3E%3Cpath d='M0.792725 12.2929L5.08562 8.00002L0.792725 3.70712L2.20694 2.29291L7.91405 8.00002L2.20694 13.7071L0.792725 12.2929Z'/%3E%3Cpath d='M7.00006 15H15.0001V13H7.00006V15Z'/%3E%3C/svg%3E"
+        sizes="any" type="image/svg+xml" />
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.cyan.min.css">
+      <style>
+        svg:not(:host),
+        svg:not(:root) {
+          overflow: hidden;
+          vertical-align: text-bottom;
         }
-    
-        function copyToClipboard() {
-          var copyText = document.getElementById("password");
-          copyText.select();
-          copyText.setSelectionRange(0, 99999);
-          document.execCommand("copy");
+
+        svg.theme-toggle {
+          display: inline-block;
+          width: auto;
+        }
+
+        svg.icon-theme-toggle {
+          --theme-toggle-duration: .4s;
+        }
+
+        svg.icon-theme-toggle.moon :first-child path {
+          d: path("M-9 3h25a1 1 0 0017 13v30H0Z");
+          transition-delay: calc(var(--theme-toggle-duration) * .4);
+          transition-timing-function:
+            cubic-bezier(0, 0, 0, 1.25);
+        }
+
+        svg.icon-theme-toggle g circle,
+        svg.icon-theme-toggle g path {
+          transform-origin: center;
+          transition: transform calc(var(--theme-toggle-duration) * .65) cubic-bezier(0, 0, 0, 1.25) calc(var(--theme-toggle-duration) * .35);
+        }
+
+        svg.icon-theme-toggle :first-child path {
+          transition-duration: calc(var(--theme-toggle-duration) * .6);
+          transition-property: transform, d;
+          transition-timing-function:
+            cubic-bezier(0, 0, .5, 1);
+        }
+
+        svg.icon-theme-toggle :first-child path {
+          transition-duration: calc(var(--theme-toggle-duration) * .6);
+          transition-property: transform, d;
+          transition-timing-function:
+            cubic-bezier(0, 0, .5, 1);
+        }
+
+        svg.icon-theme-toggle.moon g path {
+          transform: scale(.75);
+          transition-delay: 0s;
+        }
+
+        svg.icon-theme-toggle.moon g circle {
+          transform: scale(1.4);
+          transition-delay: 0s;
+        }
+
+        svg.icon-theme-toggle g circle,
+        svg.icon-theme-toggle g path {
+          transform-origin: center;
+          transition: transform calc(var(--theme-toggle-duration) * .65) cubic-bezier(0, 0, 0, 1.25) calc(var(--theme-toggle-duration) * .35);
+        }
+
+        svg.icon-theme-toggle.moon g path {
+          transform: scale(.75);
+          transition-delay: 0s;
+        }
+
+        a {
+          text-decoration-style: wavy;
+        }
+
+        main ul li a svg {
+          margin-right: 0.5rem;
+        }
+      </style>
+    </head>
+    <body class="container">
+      <header>
+        <nav>
+          <ul>
+            <li>
+              <h2>Welcome, {{lower .username}}!</h2>
+            </li>
+          </ul>
+          <ul>
+            <li><a href="/" class="contrast" style="text-decoration-style: wavy;">Controller</a></li>
+            <li><a href="#" id="theme-switcher" class="contrast"><svg xmlns="http://www.w3.org/2000/svg" width="24"
+                  height="24" viewBox="0 0 32 32" fill="currentColor" class="icon-theme-toggle theme-toggle">
+                  <clipPath id="theme-toggle-cutout">
+                    <path d="M0-11h25a1 1 0 0017 13v30H0Z"></path>
+                  </clipPath>
+                  <g clip-path="url(#theme-toggle-cutout)">
+                    <circle cx="16" cy="16" r="8.4"></circle>
+                    <path
+                      d="M18.3 3.2c0 1.3-1 2.3-2.3 2.3s-2.3-1-2.3-2.3S14.7.9 16 .9s2.3 1 2.3 2.3zm-4.6 25.6c0-1.3 1-2.3 2.3-2.3s2.3 1 2.3 2.3-1 2.3-2.3 2.3-2.3-1-2.3-2.3zm15.1-10.5c-1.3 0-2.3-1-2.3-2.3s1-2.3 2.3-2.3 2.3 1 2.3 2.3-1 2.3-2.3 2.3zM3.2 13.7c1.3 0 2.3 1 2.3 2.3s-1 2.3-2.3 2.3S.9 17.3.9 16s1-2.3 2.3-2.3zm5.8-7C9 7.9 7.9 9 6.7 9S4.4 8 4.4 6.7s1-2.3 2.3-2.3S9 5.4 9 6.7zm16.3 21c-1.3 0-2.3-1-2.3-2.3s1-2.3 2.3-2.3 2.3 1 2.3 2.3-1 2.3-2.3 2.3zm2.4-21c0 1.3-1 2.3-2.3 2.3S23 7.9 23 6.7s1-2.3 2.3-2.3 2.4 1 2.4 2.3zM6.7 23C8 23 9 24 9 25.3s-1 2.3-2.3 2.3-2.3-1-2.3-2.3 1-2.3 2.3-2.3z">
+                    </path>
+                  </g>
+                </svg></a></li>
+          </ul>
+        </nav>
+      </header>
+      <main>
+        <h3>Tools</h3>
+        <div class="grid">
+          <article>
+            <h4>IDEs</h4>
+            <ul>
+              <li><a href="./code/" target="_blank"><svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve"
+                    width="24" height="24" viewBox="0 0 512 512">
+                    <linearGradient id="visual-studio-code_svg__a" x1="256.012" x2="256.012" y1="125.867"
+                      y2="512.567" gradientTransform="matrix(1 0 0 -1 0 514)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset="0" style="stop-color:#116faf" />
+                      <stop offset=".319" style="stop-color:#247bb5" />
+                      <stop offset=".708" style="stop-color:#3585bb" />
+                      <stop offset="1" style="stop-color:#3b89bd" />
+                    </linearGradient>
+                    <path
+                      d="M493.8 55.4 388.4 4.6c-12.2-5.9-26.7-3.4-36.3 6.2L7 325.5c-9.3 8.5-9.3 23.1 0 31.5l28.2 25.6c7.6 6.9 19.1 7.4 27.2 1.2L478 68.6c13.9-10.6 34-.6 34 16.9v-1.2c0-12.4-7.1-23.6-18.2-28.9"
+                      style="fill:url(#visual-studio-code_svg__a)" />
+                    <linearGradient id="visual-studio-code_svg__b" x1="256.012" x2="256.012" y1="3.433"
+                      y2="390.133" gradientTransform="matrix(1 0 0 -1 0 514)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset="0" style="stop-color:#027bcc" />
+                      <stop offset="1" style="stop-color:#3093d6" />
+                    </linearGradient>
+                    <path
+                      d="m493.8 456.6-105.4 50.8c-12.2 5.9-26.7 3.4-36.3-6.2L7 186.5c-9.3-8.5-9.3-23.1 0-31.5l28.2-25.6c7.6-6.9 19.1-7.4 27.2-1.2L478 443.4c13.9 10.6 34 .6 34-16.9v1.2c0 12.4-7.1 23.6-18.2 28.9"
+                      style="fill:url(#visual-studio-code_svg__b)" />
+                    <linearGradient id="visual-studio-code_svg__c" x1="432.1" x2="432.1" y1="3.433"
+                      y2="512.423" gradientTransform="matrix(1 0 0 -1 0 514)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset="0" style="stop-color:#229df0" />
+                      <stop offset="1" style="stop-color:#4fb1f3" />
+                    </linearGradient>
+                    <path
+                      d="M388.5 507.4c-12.2 5.9-26.7 3.4-36.3-6.2 11.8 11.8 32 3.4 32-13.2V24.1c0-16.6-20.2-25-32-13.2 9.6-9.6 24.1-12 36.3-6.2l105.3 50.7A31.98 31.98 0 0 1 512 84.3V428c0 12.3-7.1 23.5-18.2 28.9z"
+                      style="fill:url(#visual-studio-code_svg__c)" />
+                  </svg>Code</a></li>
+              <li><a href="./jupyter/"><svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="24"
+                    height="24" viewBox="0 0 512 512">
+                    <path
+                      d="M436.5 29c.4 6.1-1.1 12.2-4.2 17.5s-7.7 9.5-13.2 12.2-11.7 3.6-17.8 2.8c-6.1-.9-11.8-3.5-16.3-7.6-4.6-4.1-7.8-9.5-9.3-15.4-1.5-6-1.2-12.2.9-18S382.4 9.7 387.4 6s10.9-5.7 17-6c4-.2 8 .4 11.8 1.7s7.3 3.4 10.3 6.1 5.4 6 7.1 9.6c1.7 3.7 2.7 7.6 2.9 11.6"
+                      style="fill:#767677" />
+                    <path
+                      d="M143.3 470.7c.5 7.7-1.3 15.4-5.2 22.1s-9.7 12-16.7 15.4-14.8 4.6-22.4 3.5c-7.7-1.1-14.8-4.4-20.6-9.6-5.7-5.2-9.8-11.9-11.7-19.4s-1.5-15.4 1.1-22.7 7.3-13.6 13.5-18.2 13.7-7.2 21.4-7.6c5.1-.3 10.1.5 14.9 2.1 4.8 1.7 9.2 4.3 12.9 7.7 3.8 3.4 6.8 7.5 9 12.1 2.3 4.5 3.6 9.5 3.8 14.6"
+                      style="fill:#9e9e9e" />
+                    <path
+                      d="M74.2 93.4c-4.4.1-8.8-1.1-12.5-3.4s-6.7-5.8-8.5-9.8-2.4-8.5-1.7-12.9 2.7-8.4 5.7-11.6 6.9-5.5 11.2-6.5 8.8-.7 13 .8c4.1 1.5 7.7 4.3 10.3 7.8 2.6 3.6 4.1 7.8 4.3 12.3.2 6-2 11.8-6.1 16.1-4.1 4.4-9.8 6.9-15.7 7.2"
+                      style="fill:#616262" />
+                    <path
+                      d="M256.3 386c-82 0-154.1-29.4-191.4-72.9 14.5 39.1 40.6 72.9 74.8 96.7s74.9 36.6 116.6 36.6 82.4-12.8 116.6-36.6 60.3-57.6 74.8-96.7c-37.2 43.5-109 72.9-191.4 72.9m0-282.7c82 0 154.1 29.4 191.4 72.9-14.5-39.1-40.6-72.9-74.8-96.7S298 42.9 256.3 42.9s-82.4 12.8-116.6 36.6-60.3 57.6-74.8 96.7c37.2-43.6 109-72.9 191.4-72.9"
+                      style="fill:#f37726" />
+                    <path
+                      d="M55.4 267.7c0 16-1.3 21.1-4.6 25-3.7 3.3-8.4 5.1-13.3 5.1l1.3 9.1c7.6.1 15-2.6 20.8-7.6 3.1-3.8 5.4-8.2 6.8-12.9s1.8-9.6 1.2-14.5v-60.3H55.4zm91.1-7.2c0 6.8 0 12.9.5 18.2h-10.8l-.7-10.8c-2.3 3.8-5.5 7-9.4 9.2s-8.3 3.3-12.7 3.2c-10.6 0-23.2-5.7-23.2-29.2v-38.9h12.2v36.5c0 12.7 3.9 21.1 14.9 21.1 2.3 0 4.5-.4 6.6-1.3s4-2.1 5.6-3.7 2.9-3.5 3.7-5.6c.9-2.1 1.3-4.4 1.3-6.6v-40.8h12.2v48.4zm23.1-26.6c0-8.5 0-15.4-.5-21.7H180l.5 11.4a26 26 0 0 1 10.2-9.8c4.2-2.3 9-3.4 13.7-3.2 16.2 0 28.4 13.6 28.4 33.8 0 23.9-14.7 35.7-30.5 35.7-4.1.2-8.1-.7-11.7-2.5s-6.7-4.6-9-8v36.5h-12zm12 17.8c0 1.7.2 3.3.5 4.9 1 4 3.4 7.6 6.7 10.2s7.4 3.9 11.5 3.9c12.9 0 20.4-10.5 20.4-25.7 0-13.3-7.1-24.7-20-24.7-5.1.4-9.8 2.7-13.4 6.3-3.5 3.7-5.6 8.5-5.8 13.6v11.5zm73-39.6 14.7 39.3c1.5 4.4 3.2 9.7 4.3 13.6 1.3-4 2.6-9.1 4.3-13.9l13.3-39H304l-18.2 47.4c-9.1 22.8-14.7 34.5-23.1 41.7-4.2 3.9-9.4 6.6-14.9 7.8l-3-10.2c3.9-1.3 7.5-3.3 10.7-5.9 4.4-3.6 8-8.2 10.3-13.5.5-.9.8-1.9 1-2.9-.1-1.1-.4-2.2-.8-3.2L241.2 212h13.3zm81.9-19.1v19.1H354v9.1h-17.5v35.9c0 8.2 2.4 12.9 9.1 12.9 2.4 0 4.8-.2 7.1-.8l.5 9.1c-3.5 1.2-7.2 1.8-10.8 1.6-2.4.2-4.9-.2-7.2-1.1s-4.3-2.2-6.1-4c-3.7-5-5.4-11.2-4.7-17.3V221H314v-9.1h10.6v-16.2zm40 54.6c-.2 3.1.2 6.2 1.3 9.1s2.8 5.6 5 7.7c2.2 2.2 4.8 3.9 7.7 5s6 1.5 9.1 1.3c6.3.1 12.5-1 18.2-3.5l2.1 9.1c-7.1 2.9-14.7 4.3-22.3 4.1-4.5.3-8.9-.4-13.1-1.9-4.2-1.6-8-4.1-11.1-7.2-3.1-3.2-5.5-7-7.1-11.2-1.5-4.2-2.1-8.7-1.7-13.1 0-20.1 11.9-35.9 31.4-35.9 21.9 0 27.3 19.1 27.3 31.4q.15 2.85 0 5.7h-47.1zm35.7-9.1c.4-2.4.2-4.9-.5-7.3s-1.9-4.6-3.5-6.4c-1.6-1.9-3.6-3.4-5.8-4.4s-4.7-1.6-7.1-1.6c-5 .4-9.7 2.6-13.2 6.2s-5.4 8.4-5.5 13.5zm29.7-5.6c0-7.8 0-14.6-.5-20.8h10.9v13h.5c1.1-4 3.5-7.6 6.8-10.2s7.3-4.1 11.4-4.4c1.1-.2 2.3-.2 3.5 0v11.4q-2.1-.3-4.2 0c-4.1.2-8.1 1.8-11.1 4.7s-4.9 6.7-5.2 10.8c-.3 1.9-.5 3.8-.5 5.7v35.5h-12V233z"
+                      style="fill:#4e4e4e" />
+                  </svg>Jupyter Lab</a></li>
+              <li><a href="./jupyter/tree" target="_blank"><svg xmlns="http://www.w3.org/2000/svg"
+                    xml:space="preserve" width="24" height="24" viewBox="0 0 512 512">
+                    <path
+                      d="M436.5 29c.4 6.1-1.1 12.2-4.2 17.5s-7.7 9.5-13.2 12.2-11.7 3.6-17.8 2.8c-6.1-.9-11.8-3.5-16.3-7.6-4.6-4.1-7.8-9.5-9.3-15.4-1.5-6-1.2-12.2.9-18S382.4 9.7 387.4 6s10.9-5.7 17-6c4-.2 8 .4 11.8 1.7s7.3 3.4 10.3 6.1 5.4 6 7.1 9.6c1.7 3.7 2.7 7.6 2.9 11.6"
+                      style="fill:#767677" />
+                    <path
+                      d="M143.3 470.7c.5 7.7-1.3 15.4-5.2 22.1s-9.7 12-16.7 15.4-14.8 4.6-22.4 3.5c-7.7-1.1-14.8-4.4-20.6-9.6-5.7-5.2-9.8-11.9-11.7-19.4s-1.5-15.4 1.1-22.7 7.3-13.6 13.5-18.2 13.7-7.2 21.4-7.6c5.1-.3 10.1.5 14.9 2.1 4.8 1.7 9.2 4.3 12.9 7.7 3.8 3.4 6.8 7.5 9 12.1 2.3 4.5 3.6 9.5 3.8 14.6"
+                      style="fill:#9e9e9e" />
+                    <path
+                      d="M74.2 93.4c-4.4.1-8.8-1.1-12.5-3.4s-6.7-5.8-8.5-9.8-2.4-8.5-1.7-12.9 2.7-8.4 5.7-11.6 6.9-5.5 11.2-6.5 8.8-.7 13 .8c4.1 1.5 7.7 4.3 10.3 7.8 2.6 3.6 4.1 7.8 4.3 12.3.2 6-2 11.8-6.1 16.1-4.1 4.4-9.8 6.9-15.7 7.2"
+                      style="fill:#616262" />
+                    <path
+                      d="M256.3 386c-82 0-154.1-29.4-191.4-72.9 14.5 39.1 40.6 72.9 74.8 96.7s74.9 36.6 116.6 36.6 82.4-12.8 116.6-36.6 60.3-57.6 74.8-96.7c-37.2 43.5-109 72.9-191.4 72.9m0-282.7c82 0 154.1 29.4 191.4 72.9-14.5-39.1-40.6-72.9-74.8-96.7S298 42.9 256.3 42.9s-82.4 12.8-116.6 36.6-60.3 57.6-74.8 96.7c37.2-43.6 109-72.9 191.4-72.9"
+                      style="fill:#f37726" />
+                    <path
+                      d="M55.4 267.7c0 16-1.3 21.1-4.6 25-3.7 3.3-8.4 5.1-13.3 5.1l1.3 9.1c7.6.1 15-2.6 20.8-7.6 3.1-3.8 5.4-8.2 6.8-12.9s1.8-9.6 1.2-14.5v-60.3H55.4zm91.1-7.2c0 6.8 0 12.9.5 18.2h-10.8l-.7-10.8c-2.3 3.8-5.5 7-9.4 9.2s-8.3 3.3-12.7 3.2c-10.6 0-23.2-5.7-23.2-29.2v-38.9h12.2v36.5c0 12.7 3.9 21.1 14.9 21.1 2.3 0 4.5-.4 6.6-1.3s4-2.1 5.6-3.7 2.9-3.5 3.7-5.6c.9-2.1 1.3-4.4 1.3-6.6v-40.8h12.2v48.4zm23.1-26.6c0-8.5 0-15.4-.5-21.7H180l.5 11.4a26 26 0 0 1 10.2-9.8c4.2-2.3 9-3.4 13.7-3.2 16.2 0 28.4 13.6 28.4 33.8 0 23.9-14.7 35.7-30.5 35.7-4.1.2-8.1-.7-11.7-2.5s-6.7-4.6-9-8v36.5h-12zm12 17.8c0 1.7.2 3.3.5 4.9 1 4 3.4 7.6 6.7 10.2s7.4 3.9 11.5 3.9c12.9 0 20.4-10.5 20.4-25.7 0-13.3-7.1-24.7-20-24.7-5.1.4-9.8 2.7-13.4 6.3-3.5 3.7-5.6 8.5-5.8 13.6v11.5zm73-39.6 14.7 39.3c1.5 4.4 3.2 9.7 4.3 13.6 1.3-4 2.6-9.1 4.3-13.9l13.3-39H304l-18.2 47.4c-9.1 22.8-14.7 34.5-23.1 41.7-4.2 3.9-9.4 6.6-14.9 7.8l-3-10.2c3.9-1.3 7.5-3.3 10.7-5.9 4.4-3.6 8-8.2 10.3-13.5.5-.9.8-1.9 1-2.9-.1-1.1-.4-2.2-.8-3.2L241.2 212h13.3zm81.9-19.1v19.1H354v9.1h-17.5v35.9c0 8.2 2.4 12.9 9.1 12.9 2.4 0 4.8-.2 7.1-.8l.5 9.1c-3.5 1.2-7.2 1.8-10.8 1.6-2.4.2-4.9-.2-7.2-1.1s-4.3-2.2-6.1-4c-3.7-5-5.4-11.2-4.7-17.3V221H314v-9.1h10.6v-16.2zm40 54.6c-.2 3.1.2 6.2 1.3 9.1s2.8 5.6 5 7.7c2.2 2.2 4.8 3.9 7.7 5s6 1.5 9.1 1.3c6.3.1 12.5-1 18.2-3.5l2.1 9.1c-7.1 2.9-14.7 4.3-22.3 4.1-4.5.3-8.9-.4-13.1-1.9-4.2-1.6-8-4.1-11.1-7.2-3.1-3.2-5.5-7-7.1-11.2-1.5-4.2-2.1-8.7-1.7-13.1 0-20.1 11.9-35.9 31.4-35.9 21.9 0 27.3 19.1 27.3 31.4q.15 2.85 0 5.7h-47.1zm35.7-9.1c.4-2.4.2-4.9-.5-7.3s-1.9-4.6-3.5-6.4c-1.6-1.9-3.6-3.4-5.8-4.4s-4.7-1.6-7.1-1.6c-5 .4-9.7 2.6-13.2 6.2s-5.4 8.4-5.5 13.5zm29.7-5.6c0-7.8 0-14.6-.5-20.8h10.9v13h.5c1.1-4 3.5-7.6 6.8-10.2s7.3-4.1 11.4-4.4c1.1-.2 2.3-.2 3.5 0v11.4q-2.1-.3-4.2 0c-4.1.2-8.1 1.8-11.1 4.7s-4.9 6.7-5.2 10.8c-.3 1.9-.5 3.8-.5 5.7v35.5h-12V233z"
+                      style="fill:#4e4e4e" />
+                  </svg>Jupyter (classic)</a></li>
+              {{- if $root.Values.applications.rstudio.enabled }}
+              <li><a href="./rstudio/" target="_blank"><svg xmlns="http://www.w3.org/2000/svg" width="24"
+                    height="24" viewBox="0 0 128 128">
+                    <path fill="#75aadb"
+                      d="M71.4 38.8c-1.5-.6-3.9-1-6.9-1.1-4.2-.1-9 .4-9.2.5v20c13.3.6 15.5-1.7 15.5-1.7 11.6-5.9 4.3-16.2.6-17.7z" />
+                    <path fill="#75aadb"
+                      d="M64 0C28.6 0 0 28.6 0 64s28.6 64 64 64 64-28.6 64-64S99.3 0 64 0zm28.6 89.8H82L64.4 63.5h-9V84h9v5.8H41.5v-5.7l7.6-.1-.1-45.9c-.8-.2-7.5-.8-7.5-.8V32c1 1 7.9 1.2 7.9 1.2 1.6.1 3.9.2 5.2-.1 9.3-1.7 16.4-.4 16.4-.4 14 3.2 14.2 15.8 10.3 22.6-3.5 5.8-10.3 7.2-10.3 7.2l14.4 21.8 7.2-.1v5.6z" />
+                    <path
+                      d="M41.595 87.073v-2.726l1.82-.141a59.125 59.125 0 013.752-.144h1.931V37.996l-.938-.127c-.516-.07-2.204-.248-3.752-.397l-2.813-.27v-2.51c0-2.332.027-2.495.39-2.3 1.583.847 10.7 1.07 15.83.388 4.202-.558 11.495-.425 14.035.257 5.483 1.472 9.11 4.646 10.824 9.473.717 2.018.817 5.847.216 8.224-.903 3.572-2.39 6.048-4.865 8.101-1.482 1.23-4.847 3.03-6.145 3.29-.397.079-.772.224-.832.321-.06.098 3.123 5.072 7.075 11.054l7.184 10.876 3.633-.068 3.634-.068V89.8l-5.242-.008-5.24-.007-8.82-13.234-8.817-13.234h-9.178V84.061h9.049V89.8H41.595zm25.158-29.162c3.476-.55 7.265-2.774 8.973-5.263 2.511-3.663 1.537-8.99-2.294-12.547-1.357-1.26-2.205-1.63-4.794-2.1-2.124-.386-8.66-.454-11.706-.122l-1.544.168-.058 10.083-.057 10.082.72.106c1.366.2 8.67-.075 10.76-.407z"
+                      fill="#fff" stroke="#fff" stroke-width=".788" />
+                  </svg>R-Studio</a></li>
+              {{- end }}
+            </ul>
+          </article>
+          <article>
+            <h4>Applications</h4>
+            <ul>
+              <li><a href="./airflow/" target="_blank"><svg width="24" height="24" viewBox="0 0 128 128"
+                    xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="m2.5441 127 60.809-62.332a1.124 1.124 0 0 0 0.1359-1.4368c-3.6977-5.1625-10.521-6.0578-13.05-9.5268-7.4903-10.275-9.3909-16.092-12.61-15.731a0.98374 0.98374 0 0 0-0.58464 0.3085l-21.966 22.518c-12.638 12.944-14.454 41.475-14.782 65.367a1.1908 1.1908 0 0 0 2.0473 0.83273z"
+                      fill="#017cee" />
+                    <path
+                      d="m126.99 125.46-62.332-60.813a1.124 1.124 0 0 0-1.4389-0.1359c-5.1625 3.6998-6.0578 10.521-9.5268 13.05-10.275 7.4903-16.092 9.3909-15.731 12.61a0.98374 0.98374 0 0 0 0.3085 0.58248l22.518 21.966c12.944 12.638 41.475 14.454 65.367 14.782a1.1908 1.1908 0 0 0 0.83489-2.0408z"
+                      fill="#00ad46" />
+                    <path
+                      d="m60.792 112.72c-7.076-6.9035-10.355-20.559 3.2058-48.719-22.046 9.8525-29.771 22.803-25.972 26.511z"
+                      fill="#04d659" />
+                    <path
+                      d="m125.45 1.0113-60.807 62.332a1.1218 1.1218 0 0 0-0.1359 1.4368c3.6998 5.1625 10.519 6.0578 13.05 9.5268 7.4903 10.275 9.393 16.092 12.61 15.731a0.97943 0.97943 0 0 0 0.58464-0.3085l21.966-22.518c12.638-12.944 14.454-41.475 14.782-65.367a1.193 1.193 0 0 0-2.0495-0.83273z"
+                      fill="#00c7d4" />
+                    <path
+                      d="m112.73 67.211c-6.9035 7.076-20.559 10.355-48.721-3.2058 9.8525 22.046 22.803 29.771 26.511 25.972z"
+                      fill="#11e1ee" />
+                    <path
+                      d="m1.0017 2.5495 62.332 60.807a1.124 1.124 0 0 0 1.4368 0.1359c5.1625-3.6998 6.0578-10.521 9.5268-13.05 10.275-7.4903 16.092-9.3909 15.731-12.61a0.99022 0.99022 0 0 0-0.3085-0.58463l-22.518-21.966c-12.944-12.638-41.475-14.454-65.367-14.782a1.1908 1.1908 0 0 0-0.83273 2.0495z"
+                      fill="#e43921" />
+                    <path
+                      d="m67.212 15.284c7.076 6.9035 10.355 20.559-3.2058 48.721 22.046-9.8525 29.771-22.805 25.972-26.511z"
+                      fill="#ff7557" />
+                    <path
+                      d="m15.279 60.8c6.9035-7.076 20.559-10.355 48.721 3.2058-9.8525-22.046-22.803-29.771-26.511-25.972z"
+                      fill="#0cb6ff" />
+                    <circle cx="64.009" cy="63.995" r="2.7182" fill="#4a4848" />
+                  </svg>Airflow</a></li>
+              <li><a href="./mlflow/" target="_blank"><svg role="img" width="24" height="24" viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg">
+                    <title>MLflow</title>
+                    <path
+                      d="M11.883.002a12.044 12.044 0 0 0-9.326 19.463l3.668-2.694A7.573 7.573 0 0 1 12.043 4.45v2.867l6.908-5.14A12.012 12.012 0 0 0 11.883.002zm9.562 4.533L17.777 7.23a7.573 7.573 0 0 1-5.818 12.322v-2.867l-6.908 5.14a12.046 12.046 0 0 0 16.394-17.29z" />
+                  </svg>MLflow</a></li>
+            </ul>
+          </article>
+          <article>
+            <h4>Other</h4>
+            <ul>
+              <li><a href="./browser/" target="_blank"><svg xmlns="http://www.w3.org/2000/svg"
+                    xml:space="preserve" width="24" height="24" viewBox="0 0 512 512">
+                    <linearGradient id="firefox_svg__a" x1="472.337" x2="52.763" y1="358.518" y2="763.335"
+                      gradientTransform="translate(-2.52 -266.419)scale(.9643)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset=".048" style="stop-color:#fff44f" />
+                      <stop offset=".111" style="stop-color:#ffe847" />
+                      <stop offset=".225" style="stop-color:#ffc830" />
+                      <stop offset=".368" style="stop-color:#ff980e" />
+                      <stop offset=".401" style="stop-color:#ff8b16" />
+                      <stop offset=".462" style="stop-color:#ff672a" />
+                      <stop offset=".534" style="stop-color:#ff3647" />
+                      <stop offset=".705" style="stop-color:#e31587" />
+                    </linearGradient>
+                    <path
+                      d="M485.9 171.9c-10.8-25.9-32.7-54-49.8-62.8 12.2 23.7 20.7 49.1 25.1 75.3v.4c-28.1-69.9-75.6-98.2-114.5-159.6-2-3.1-3.9-6.2-5.9-9.5-1.1-1.9-2-3.5-2.7-5.1-1.6-3.1-2.8-6.4-3.7-9.8 0-.3-.2-.6-.6-.7h-.5l-.1.1s-.1.1-.2.1l.1-.2c-62.4 36.5-83.5 104.1-85.4 137.9-24.9 1.7-48.7 10.9-68.3 26.3-2.1-1.8-4.2-3.3-6.4-4.8-5.7-19.8-5.9-40.8-.7-60.7a183.2 183.2 0 0 0-59.7 46.2h-.1c-9.8-12.5-9.1-53.6-8.5-62.2-2.9 1.2-5.7 2.7-8.2 4.4-8.8 6.1-16.9 13.1-24.4 20.8-8.5 8.6-16.3 18-23.2 27.8-15.9 22.6-27.3 48.1-33.3 75.2l-.3 1.7c-.5 2.2-2.2 13.2-2.5 15.5 0 .2 0 .4-.1.6-2.2 11.3-3.5 22.7-4 34.2v1.3c.2 137.1 111.6 248 248.6 247.8 120.6-.2 223.6-87 244.1-205.8.4-3.2.8-6.4 1.1-9.6 5.3-42.4-.2-85.2-15.9-124.8M199.8 366.2c1.2.6 2.3 1.2 3.4 1.7l.2.1q-1.65-.9-3.6-1.8m261.5-181.3v-.2z"
+                      style="fill:url(#firefox_svg__a)" />
+                    <radialGradient id="firefox_svg__b" cx="-7665.701" cy="-8344.235" r="526.888"
+                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset=".129" style="stop-color:#ffbd4f" />
+                      <stop offset=".186" style="stop-color:#ffac31" />
+                      <stop offset=".247" style="stop-color:#ff9d17" />
+                      <stop offset=".283" style="stop-color:#ff980e" />
+                      <stop offset=".403" style="stop-color:#ff563b" />
+                      <stop offset=".467" style="stop-color:#ff3750" />
+                      <stop offset=".71" style="stop-color:#f5156c" />
+                      <stop offset=".782" style="stop-color:#eb0878" />
+                      <stop offset=".86" style="stop-color:#e50080" />
+                    </radialGradient>
+                    <path
+                      d="M485.9 171.9c-10.8-25.9-32.7-54-49.8-62.8 12.2 23.7 20.7 49.1 25.1 75.3v.5c19.1 54.7 16.4 114.8-7.8 167.5-28.5 61.1-97.3 123.6-205 120.5C132 469.6 29.4 383.1 10.3 270c-3.5-17.9 0-26.9 1.8-41.4-2.4 11.3-3.7 22.7-4 34.3v1.3c.2 137.1 111.6 248 248.6 247.8 120.7-.1 223.6-86.9 244.2-205.7.4-3.2.8-6.4 1.1-9.6 5.1-42.4-.4-85.2-16.1-124.8"
+                      style="fill:url(#firefox_svg__b)" />
+                    <radialGradient id="firefox_svg__c" cx="-7864.917" cy="-8125.098" r="526.888"
+                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset=".3" style="stop-color:#960e18" />
+                      <stop offset=".351" style="stop-color:#b11927;stop-opacity:.74" />
+                      <stop offset=".435" style="stop-color:#db293d;stop-opacity:.343" />
+                      <stop offset=".497" style="stop-color:#f5334b;stop-opacity:9.400000e-02" />
+                      <stop offset=".53" style="stop-color:#ff3750;stop-opacity:0" />
+                    </radialGradient>
+                    <path
+                      d="M485.9 171.9c-10.8-25.9-32.7-54-49.8-62.8 12.2 23.7 20.7 49.1 25.1 75.3v.5c19.1 54.7 16.4 114.8-7.8 167.5-28.5 61.1-97.3 123.6-205 120.5C132 469.6 29.4 383.1 10.3 270c-3.5-17.9 0-26.9 1.8-41.4-2.4 11.3-3.7 22.7-4 34.3v1.3c.2 137.1 111.6 248 248.6 247.8 120.7-.1 223.6-86.9 244.2-205.7.4-3.2.8-6.4 1.1-9.6 5.1-42.4-.4-85.2-16.1-124.8"
+                      style="fill:url(#firefox_svg__c)" />
+                    <radialGradient id="firefox_svg__d" cx="-7798.511" cy="-8463.765" r="381.667"
+                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset=".132" style="stop-color:#fff44f" />
+                      <stop offset=".252" style="stop-color:#ffdc3e" />
+                      <stop offset=".506" style="stop-color:#ff9d12" />
+                      <stop offset=".526" style="stop-color:#ff980e" />
+                    </radialGradient>
+                    <path
+                      d="M365.3 201c.5.4 1.1.8 1.6 1.2-6.2-11.1-14-21.2-23.1-30C266.6 95 323.6 4.8 333.1.2l.1-.1c-62.4 36.5-83.5 104.1-85.4 137.9 2.8-.2 5.8-.4 8.7-.4 45.1 0 86.6 24.3 108.8 63.4"
+                      style="fill:url(#firefox_svg__d)" />
+                    <radialGradient id="firefox_svg__e" cx="-7924.681" cy="-7985.648" r="250.858"
+                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset=".353" style="stop-color:#3a8ee6" />
+                      <stop offset=".472" style="stop-color:#5c79f0" />
+                      <stop offset=".669" style="stop-color:#9059ff" />
+                      <stop offset="1" style="stop-color:#c139e6" />
+                    </radialGradient>
+                    <path
+                      d="M256.7 216.5c-.4 6.2-22.2 27.5-29.9 27.5-70.6 0-82 42.7-82 42.7 3.1 35.9 28.2 65.6 58.4 81.2 1.4.7 2.7 1.4 4.2 2 2.5 1.1 4.8 2.1 7.3 2.9 10.4 3.6 21.3 5.8 32.3 6.2 123.7 5.8 147.7-147.9 58.4-192.6 21-2.7 42.4 2.5 59.8 14.5-22.2-39.2-63.7-63.4-108.7-63.5-2.9 0-5.8.2-8.7.4-24.9 1.7-48.7 10.9-68.3 26.3 3.8 3.2 8.1 7.5 17.1 16.3 16.8 16.8 60 34 60.1 36.1"
+                      style="fill:url(#firefox_svg__e)" />
+                    <radialGradient id="firefox_svg__f" cx="-7965.277" cy="-8188.533" r="133.026"
+                      gradientTransform="matrix(.9373 -.2266 .2651 1.0974 9907.315 7405.453)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset=".206" style="stop-color:#9059ff;stop-opacity:0" />
+                      <stop offset=".278" style="stop-color:#8c4ff3;stop-opacity:6.400000e-02" />
+                      <stop offset=".747" style="stop-color:#7716a8;stop-opacity:.45" />
+                      <stop offset=".975" style="stop-color:#6e008b;stop-opacity:.6" />
+                    </radialGradient>
+                    <path
+                      d="M256.7 216.5c-.4 6.2-22.2 27.5-29.9 27.5-70.6 0-82 42.7-82 42.7 3.1 35.9 28.2 65.6 58.4 81.2 1.4.7 2.7 1.4 4.2 2 2.5 1.1 4.8 2.1 7.3 2.9 10.4 3.6 21.3 5.8 32.3 6.2 123.7 5.8 147.7-147.9 58.4-192.6 21-2.7 42.4 2.5 59.8 14.5-22.2-39.2-63.7-63.4-108.7-63.5-2.9 0-5.8.2-8.7.4-24.9 1.7-48.7 10.9-68.3 26.3 3.8 3.2 8.1 7.5 17.1 16.3 16.8 16.8 60 34 60.1 36.1"
+                      style="fill:url(#firefox_svg__f)" />
+                    <radialGradient id="firefox_svg__g" cx="-7871.557" cy="-8364.156" r="180.498"
+                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset="0" style="stop-color:#ffe226" />
+                      <stop offset=".121" style="stop-color:#ffdb27" />
+                      <stop offset=".295" style="stop-color:#ffc82a" />
+                      <stop offset=".502" style="stop-color:#ffa930" />
+                      <stop offset=".732" style="stop-color:#ff7e37" />
+                      <stop offset=".792" style="stop-color:#ff7139" />
+                    </radialGradient>
+                    <path
+                      d="M167.9 156.1c2 1.3 3.6 2.4 5.1 3.4-5.7-19.8-5.9-40.8-.7-60.7a183.2 183.2 0 0 0-59.7 46.2c1.2 0 37.3-.7 55.3 11.1"
+                      style="fill:url(#firefox_svg__g)" />
+                    <radialGradient id="firefox_svg__h" cx="-7725.465" cy="-8483.686" r="770.116"
+                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset=".113" style="stop-color:#fff44f" />
+                      <stop offset=".456" style="stop-color:#ff980e" />
+                      <stop offset=".622" style="stop-color:#ff5634" />
+                      <stop offset=".716" style="stop-color:#ff3647" />
+                      <stop offset=".904" style="stop-color:#e31587" />
+                    </radialGradient>
+                    <path
+                      d="M10.3 270.1C29.5 383.2 132.1 469.7 248.5 473c107.7 3 176.6-59.5 205-120.5 24.1-52.7 26.8-112.7 7.8-167.5v-.4.4c8.8 57.4-20.4 113.1-66.2 150.8l-.1.3c-89.1 72.6-174.3 43.8-191.5 32-1.2-.6-2.5-1.2-3.6-1.8-51.9-24.8-73.4-72.1-68.7-112.7-25.1.4-48.2-14.1-58.8-37 27.7-17 62.3-18.4 91.2-3.6 29.4 13.4 62.8 14.6 93.2 3.6-.1-2.1-43.3-19.2-60.1-35.8-9-8.8-13.3-13.2-17.1-16.3-2.1-1.8-4.2-3.3-6.4-4.8-1.5-1-3.1-2.1-5.1-3.4-18.1-11.8-54.1-11.1-55.3-11.1h-.1c-9.8-12.5-9.1-53.6-8.5-62.2-2.9 1.2-5.7 2.7-8.2 4.4-8.6 6.2-16.8 13.2-24.3 20.8-8.5 8.5-16.3 17.9-23.3 27.8-16 22.5-27.4 48.1-33.4 75.2-.3.4-9 38.9-4.7 58.9"
+                      style="fill:url(#firefox_svg__h)" />
+                    <radialGradient id="firefox_svg__i" cx="-7876.41" cy="-9224.912" r="564.057"
+                      gradientTransform="matrix(.1012 .9595 -.6296 .06654 -4694.67 8136.184)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset="0" style="stop-color:#fff44f" />
+                      <stop offset=".06" style="stop-color:#ffe847" />
+                      <stop offset=".168" style="stop-color:#ffc830" />
+                      <stop offset=".304" style="stop-color:#ff980e" />
+                      <stop offset=".356" style="stop-color:#ff8b16" />
+                      <stop offset=".455" style="stop-color:#ff672a" />
+                      <stop offset=".57" style="stop-color:#ff3647" />
+                      <stop offset=".737" style="stop-color:#e31587" />
+                    </radialGradient>
+                    <path
+                      d="M343.8 172.1c9 8.9 16.8 19.1 23.1 30 1.4 1 2.7 2.1 3.7 3 56.3 51.8 26.8 125.2 24.5 130.4 45.7-37.6 74.9-93.3 66.1-150.8-28.1-70-75.7-98.2-114.5-159.7-2-3.1-3.9-6.2-5.9-9.5-1.1-1.9-2-3.5-2.7-5.1-1.6-3.1-2.8-6.4-3.7-9.8 0-.3-.2-.6-.6-.7h-.5l-.1.1s-.1.1-.2.1c-9.6 4.5-66.6 94.7 10.6 171.8z"
+                      style="fill:url(#firefox_svg__i)" />
+                    <radialGradient id="firefox_svg__j" cx="-7871.557" cy="-8297.752" r="480.72"
+                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset=".137" style="stop-color:#fff44f" />
+                      <stop offset=".48" style="stop-color:#ff980e" />
+                      <stop offset=".592" style="stop-color:#ff5634" />
+                      <stop offset=".655" style="stop-color:#ff3647" />
+                      <stop offset=".904" style="stop-color:#e31587" />
+                    </radialGradient>
+                    <path
+                      d="M370.5 205.3c-1.1-1-2.4-2.1-3.7-3-.5-.4-1-.8-1.6-1.2-17.5-12.1-38.8-17.3-59.8-14.5 89.3 44.7 65.3 198.4-58.4 192.6-11-.5-21.9-2.6-32.3-6.2-2.5-.9-4.8-1.9-7.3-2.9-1.4-.7-2.8-1.3-4.2-2l.2.1c17.3 11.8 102.4 40.6 191.5-32l.1-.3c2.3-5.4 31.8-78.7-24.5-130.6"
+                      style="fill:url(#firefox_svg__j)" />
+                    <radialGradient id="firefox_svg__k" cx="-7745.387" cy="-8271.19" r="526.17"
+                      gradientTransform="translate(7829.102 8104.021)scale(.9643)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset=".094" style="stop-color:#fff44f" />
+                      <stop offset=".231" style="stop-color:#ffe141" />
+                      <stop offset=".509" style="stop-color:#ffaf1e" />
+                      <stop offset=".626" style="stop-color:#ff980e" />
+                    </radialGradient>
+                    <path
+                      d="M144.8 286.6s11.5-42.7 82-42.7c7.7 0 29.5-21.3 29.9-27.5-30.3 11-63.8 9.7-93.2-3.6-29-14.7-63.5-13.4-91.2 3.6 10.6 22.9 33.6 37.3 58.8 37-4.6 40.6 16.9 87.9 68.7 112.7 1.2.6 2.3 1.2 3.4 1.7-30.3-15.6-55.3-45.3-58.4-81.2"
+                      style="fill:url(#firefox_svg__k)" />
+                    <linearGradient id="firefox_svg__l" x1="467.354" x2="110.401" y1="356.528" y2="713.547"
+                      gradientTransform="translate(-2.52 -266.419)scale(.9643)"
+                      gradientUnits="userSpaceOnUse">
+                      <stop offset=".167" style="stop-color:#fff44f;stop-opacity:.8" />
+                      <stop offset=".266" style="stop-color:#fff44f;stop-opacity:.634" />
+                      <stop offset=".489" style="stop-color:#fff44f;stop-opacity:.217" />
+                      <stop offset=".6" style="stop-color:#fff44f;stop-opacity:0" />
+                    </linearGradient>
+                    <path
+                      d="M485.9 171.9c-10.8-25.9-32.7-54-49.8-62.8 12.2 23.7 20.7 49.1 25.1 75.3v.4c-28.1-69.9-75.6-98.2-114.5-159.6-2-3.1-3.9-6.2-5.9-9.5-1.1-1.9-2-3.5-2.7-5.1-1.6-3.1-2.8-6.4-3.7-9.8 0-.3-.2-.6-.6-.7h-.5l-.1.1s-.1.1-.2.1l.1-.2c-62.4 36.5-83.5 104.1-85.4 137.9 2.8-.2 5.8-.4 8.7-.4 45 .1 86.5 24.4 108.7 63.5-17.5-12.1-38.8-17.3-59.8-14.5 89.3 44.7 65.3 198.4-58.4 192.6-11-.5-21.9-2.6-32.3-6.2-2.5-.9-4.8-1.9-7.3-2.9-1.4-.7-2.8-1.3-4.2-2l.2.1c-1.2-.6-2.5-1.2-3.6-1.8 1.2.6 2.3 1.2 3.4 1.7-30.3-15.7-55.3-45.3-58.4-81.2 0 0 11.5-42.7 82-42.7 7.7 0 29.5-21.3 29.9-27.5-.1-2.1-43.3-19.2-60.1-35.8-9-8.8-13.3-13.2-17.1-16.3-2.1-1.8-4.2-3.3-6.4-4.8-5.7-19.8-5.9-40.8-.7-60.7a183.2 183.2 0 0 0-59.7 46.2h.1c-9.8-12.5-9.1-53.6-8.5-62.2-2.9 1.2-5.7 2.7-8.2 4.4-8.6 6.2-16.8 13.2-24.3 20.8-8.5 8.6-16.3 18-23.2 27.8-15.9 22.6-27.3 48.1-33.3 75.2l-.3 1.7c-.5 2.2-2.6 13.3-2.8 15.6-2 11.5-3.1 23-3.6 34.6v1.3C8.6 401.4 119.9 512.2 257 512c120.6-.2 223.5-87 244.1-205.8.4-3.2.8-6.4 1.1-9.6 4.9-42.2-.6-85.1-16.3-124.7m-24.7 12.7v.3z"
+                      style="fill:url(#firefox_svg__l)" />
+                  </svg>Firefox</a></li>
+              <li><a href="https://analyticsldt.atlassian.net/wiki/spaces/EED/pages/3026288727/DataOps"
+                  target="_blank"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                    viewBox="0 0 128 128">
+                    <defs>
+                      <linearGradient id="confluence-original-a" gradientUnits="userSpaceOnUse"
+                        x1="26.791" y1="28.467" x2="11.792" y2="19.855" gradientTransform="scale(4)">
+                        <stop offset="0" stop-color="#0052cc" />
+                        <stop offset=".918" stop-color="#2380fb" />
+                        <stop offset="1" stop-color="#2684ff" />
+                      </linearGradient>
+                      <linearGradient id="confluence-original-b" gradientUnits="userSpaceOnUse" x1="5.209"
+                        y1="2.523" x2="20.208" y2="11.136" gradientTransform="scale(4)">
+                        <stop offset="0" stop-color="#0052cc" />
+                        <stop offset=".918" stop-color="#2380fb" />
+                        <stop offset="1" stop-color="#2684ff" />
+                      </linearGradient>
+                    </defs>
+                    <path
+                      d="M19.492 86.227a249.047 249.047 0 00-3.047 4.933c-.867 1.45-.433 3.336 1.016 4.207l19.863 12.188c1.45.87 3.332.433 4.203-1.016a139.349 139.349 0 012.899-4.934c7.832-12.91 15.804-11.46 30.011-4.64l19.72 9.281c1.593.727 3.335 0 4.058-1.45l9.426-21.323c.722-1.453 0-3.336-1.454-4.063-4.203-1.887-12.464-5.805-19.714-9.43-26.82-12.914-49.586-12.043-66.98 16.247zm0 0"
+                      fill="url(#confluence-original-a)" />
+                    <path
+                      d="M108.508 37.773a249.047 249.047 0 003.047-4.933c.87-1.45.433-3.336-1.016-4.207L90.676 16.445c-1.45-.87-3.332-.433-4.203 1.016a133.55 133.55 0 01-2.899 4.934c-7.832 12.91-15.804 11.46-30.011 4.64l-19.72-9.281c-1.593-.727-3.331 0-4.058 1.45l-9.422 21.323c-.726 1.453 0 3.34 1.45 4.063 4.203 1.887 12.468 5.805 19.714 9.43 26.825 12.77 49.586 12.042 66.98-16.247zm0 0"
+                      fill="url(#confluence-original-b)" />
+                  </svg>Confluence</a></li>
+            </ul>
+          </article>
+        </div>
+        <hr />
+        <h3>Instructions</h3>
+        <h4>Mlflow</h4>
+        <p>
+          Tracking URI for cluster internal use: <a>http://shared-space:5000</a>
+        </p>
+        <h4>SSH Tunnel</h4>
+        <p>
+          Download <a href="{{ $root.Values.ssh.clientDownloadLink }}">ws-tunnel</a> and execute:
+        </p>
+        <p>
+          <kbd>ws-tunnel wss://{{ $root.Values.ingress.host }}/{{lower .username}}/ssh</kbd>
+        </p>
+        <p>
+          Then connect to the port exposed:
+        </p>
+        <p>
+          <kbd>ssh {{lower .username}}@localhost -p EXPOSED_PORT</kbd>
+        </p>
+      </main>
+      <script>
+        function switchTheme(e) {
+          if (document.documentElement.getAttribute('data-theme') == 'light') {
+            document.documentElement.setAttribute('data-theme', 'dark')
+            document.querySelector('#theme-switcher svg').classList.remove('moon')
+          } else {
+            document.documentElement.setAttribute('data-theme', 'light')
+            document.querySelector('#theme-switcher svg').classList.add('moon')
+          }
+        }
+        function onLoad() {
+          let bt = document.getElementById('theme-switcher')
+          bt.addEventListener('click', switchTheme)
         }
         onLoad();
       </script>

--- a/developer-env/templates/configmaps/user-apps-html.yaml
+++ b/developer-env/templates/configmaps/user-apps-html.yaml
@@ -165,21 +165,28 @@ data:
     	</main>
     
     	<script>
-    		function switchTheme(e) {
+    		function setTheme(theme) {
+          if (!theme) return;
+          localStorage.setItem('user-theme', theme)
+          document.documentElement.setAttribute('data-theme', theme)
+          if (theme == 'light') {
+            document.querySelector('#theme-switcher svg').classList.add('moon')
+          } else {
+            document.querySelector('#theme-switcher svg').classList.remove('moon')
+          }
+        }
+    		function toggleTheme(e) {
     			if (document.documentElement.getAttribute('data-theme') == 'light') {
-    				document.documentElement.setAttribute('data-theme', 'dark')
-    				document.querySelector('#theme-switcher svg').classList.remove('moon')
+    				setTheme('dark')
     			} else {
-    				document.documentElement.setAttribute('data-theme', 'light')
-    				document.querySelector('#theme-switcher svg').classList.add('moon')
+    				setTheme('light')
     			}
     		}
-    
     		function onLoad() {
+          setTheme(localStorage.getItem('user-theme'))
     			let bt = document.getElementById('theme-switcher')
-    			bt.addEventListener('click', switchTheme)
+    			bt.addEventListener('click', toggleTheme)
     		}
-    
     		onLoad();
     	</script>
     </body>


### PR DESCRIPTION
Utilizando a lib [picocss](https://picocss.com/) para melhorar o estilo da home dos usuários no ambiente dev.

Poucas alterações de estrutura, pois o pico é semântico, então ele estiliza por tag e não por classe.

Prévia do resultado:

<img width="1605" height="1204" alt="image" src="https://github.com/user-attachments/assets/146e2974-2657-44e8-b5cb-80255f9840b6" />

<img width="1556" height="1195" alt="image" src="https://github.com/user-attachments/assets/e92b3e8f-d759-4516-ae12-c4e2de77b9fe" />

